### PR TITLE
Billing: invoice search & enforce numbers

### DIFF
--- a/src/AppHost/AspireProjectBuilder.cs
+++ b/src/AppHost/AspireProjectBuilder.cs
@@ -17,13 +17,13 @@ public class AspireProjectBuilder
 
     private readonly string? _keyVault;
 
-/// <summary>
-/// Aspire Project Builder constructor. Initializes the builder with optional SQL Server and Azure SQL Server resources, and an optional Key Vault reference.
-/// </summary>
-/// <param name="builder"></param>
-/// <param name="sqlServer"></param>
-/// <param name="sqlAzureServer"></param>
-/// <param name="keyVault"></param>
+    /// <summary>
+    /// Aspire Project Builder constructor. Initializes the builder with optional SQL Server and Azure SQL Server resources, and an optional Key Vault reference.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="sqlServer"></param>
+    /// <param name="sqlAzureServer"></param>
+    /// <param name="keyVault"></param>
     public AspireProjectBuilder(
         IDistributedApplicationBuilder builder,
         IResourceBuilder<SqlServerServerResource>? sqlServer = null,
@@ -37,22 +37,26 @@ public class AspireProjectBuilder
         _keyVault = keyVault;
     }
 
-/// <summary>
-/// Add Web Project. Creates a new project with the specified type and adds it to the builder. The project is configured with Dapr, environment variables, and optional Redis and Application Insights resources.
-/// </summary>
-/// <typeparam name="T"></typeparam>
-/// <param name="redis"></param>
-/// <param name="origin"></param>
-/// <param name="isDeployment"></param>
-/// <param name="applicationInsights"></param>
-/// <param name="hasDatabase"></param>
-/// <returns></returns>
-/// <exception cref="ArgumentException"></exception>
+    /// <summary>
+    /// Add Web Project. Creates a new project with the specified type and adds it to the builder. The project is configured with Dapr, environment variables, and optional Redis and Application Insights resources.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="redis"></param>
+    /// <param name="origin"></param>
+    /// <param name="isDeployment"></param>
+    /// <param name="applicationInsights"></param>
+    /// <param name="pubSub"></param>
+    /// <param name="stateStore"></param>
+    /// <param name="hasDatabase"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
     public IResourceBuilder<ProjectResource> AddWebProject<T>(
         IResourceBuilder<RedisResource>? redis = null,
         string? origin = null,
         bool isDeployment = false,
         IResourceBuilder<AzureApplicationInsightsResource>? applicationInsights = null,
+        IResourceBuilder<IDaprComponentResource>? pubSub = null,
+        IResourceBuilder<IDaprComponentResource>? stateStore = null,
         bool hasDatabase = true)
         where T : IProjectMetadata, new()
     {
@@ -87,20 +91,21 @@ public class AspireProjectBuilder
         // Add project
         var project = _builder.AddProject<T>(serviceResourceName);
 
+        var sidecarOptions = new DaprSidecarOptions
+        {
+            AppId = daprAppId,
+            AppPort = httpPort,
+            // Note: Placement and Scheduler connection errors are harmless warnings.
+            // - Placement (port 6050): Only needed for Dapr Actors (we don't use actors)
+            // - Scheduler (port 6060): Only needed for scheduled jobs/workflows (we don't use)
+            // PubSub and State Store work perfectly without these services.
+        };
         // Configure project
         // Note: Aspire uses its own integrated Dapr runtime version (currently 1.15.x)
         // The Dapr CLI installation in DevContainer does not affect the sidecar version
         // Scheduler and Placement connection errors are harmless warnings (not used)
         project = project
-            .WithDaprSidecar(new DaprSidecarOptions
-            {
-                AppId = daprAppId,
-                AppPort = httpPort,
-                // Note: Placement and Scheduler connection errors are harmless warnings.
-                // - Placement (port 6050): Only needed for Dapr Actors (we don't use actors)
-                // - Scheduler (port 6060): Only needed for scheduled jobs/workflows (we don't use)
-                // PubSub and State Store work perfectly without these services.
-            })
+            .WithDaprSidecar(CreateSidecarMapping(sidecarOptions, pubSub, stateStore))
             .WithEnvironment("Jwt__SecretKey", _builder.Configuration["Jwt:SecretKey"])
             .WithEnvironment("Jwt__Issuer", _builder.Configuration["Jwt:Issuer"])
             .WithEnvironment("Jwt__Audience", _builder.Configuration["Jwt:Audience"])
@@ -139,6 +144,20 @@ public class AspireProjectBuilder
                 .WithReference(redis);
 
         return project;
+
+        static Action<IResourceBuilder<IDaprSidecarResource>> CreateSidecarMapping(
+            DaprSidecarOptions sidecarOptions,
+            IResourceBuilder<IDaprComponentResource>? pubSub,
+            IResourceBuilder<IDaprComponentResource>? stateStore)
+        {
+            if (pubSub is not null)
+                if (stateStore is not null)
+                    return sidecar => sidecar.WithOptions(sidecarOptions).WithReference(stateStore).WithReference(pubSub);
+                else
+                    return sidecar => sidecar.WithOptions(sidecarOptions).WithReference(pubSub);
+
+            return sidecar => sidecar.WithOptions(sidecarOptions);
+        }
     }
 
     // Optionally reset counters

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -59,25 +59,25 @@ var jwtIssuer = builder.Configuration["Jwt:Issuer"] ?? "MyApp.Auth";
 var jwtAudience = builder.Configuration["Jwt:Audience"] ?? "MyApp.All";
 
 // Add projects - ports auto-increment
-var authService = projectBuilder.AddWebProject<Projects.MyApp_Auth_API>(redis, origin, isDeployment, applicationInsights);
+var authService = projectBuilder.AddWebProject<Projects.MyApp_Auth_API>(redis, origin, isDeployment, applicationInsights, pubSub, stateStore);
 // Creates: AuthDB, auth-service, ports 6001, 3501, 46001, 9091
 
-var billingService = projectBuilder.AddWebProject<Projects.MyApp_Billing_API>(redis, origin, isDeployment, applicationInsights);
+var billingService = projectBuilder.AddWebProject<Projects.MyApp_Billing_API>(redis, origin, isDeployment, applicationInsights, pubSub, stateStore);
 // Creates: BillingDB, billing-service, ports 6002, 3502, 45002, 9092
 
-var crmService = projectBuilder.AddWebProject<Projects.MyApp_Crm_API>(redis, origin, isDeployment, applicationInsights);
+var crmService = projectBuilder.AddWebProject<Projects.MyApp_Crm_API>(redis, origin, isDeployment, applicationInsights, pubSub, stateStore);
 // Creates: CrmDB, crm-service, ports 6003, 3503, 45003, 9093
 
-var inventoryService = projectBuilder.AddWebProject<Projects.MyApp_Inventory_API>(redis, origin, isDeployment, applicationInsights);
+var inventoryService = projectBuilder.AddWebProject<Projects.MyApp_Inventory_API>(redis, origin, isDeployment, applicationInsights, pubSub, stateStore);
 // Creates: InventoryDB, inventory-service, ports 6004, 3504, 45004, 9094
 
-var ordersService = projectBuilder.AddWebProject<Projects.MyApp_Orders_API>(redis, origin, isDeployment, applicationInsights);
+var ordersService = projectBuilder.AddWebProject<Projects.MyApp_Orders_API>(redis, origin, isDeployment, applicationInsights, pubSub, stateStore);
 // Creates: OrderDB, orders-service, ports 6005, 3505, 45005, 9095
 
-var purchasingService = projectBuilder.AddWebProject<Projects.MyApp_Purchasing_API>(redis, origin, isDeployment, applicationInsights);
+var purchasingService = projectBuilder.AddWebProject<Projects.MyApp_Purchasing_API>(redis, origin, isDeployment, applicationInsights, pubSub, stateStore);
 // Creates: PurchasingDB, purchasing-service, ports 6006, 3506, 45006, 9096
 
-var salesService = projectBuilder.AddWebProject<Projects.MyApp_Sales_API>(redis, origin, isDeployment, applicationInsights);
+var salesService = projectBuilder.AddWebProject<Projects.MyApp_Sales_API>(redis, origin, isDeployment, applicationInsights, pubSub, stateStore);
 // Creates: SalesDB, sales-service, ports 6007, 3507, 45007, 9097
 
 var skService = projectBuilder.AddWebProject<Projects.MyApp_SemanticKernel>(redis, origin, isDeployment, applicationInsights, hasDatabase: false);

--- a/src/MyApp.Billing/MyApp.Billing.API/Controllers/CreditNotesController.cs
+++ b/src/MyApp.Billing/MyApp.Billing.API/Controllers/CreditNotesController.cs
@@ -11,7 +11,7 @@ namespace MyApp.Billing.API.Controllers;
 /// <summary>
 /// Read-only access to credit notes. Credit notes are created via POST /api/invoices/{id}/credit-notes.
 /// </summary>
-[Route("api/[controller]")]
+[Route("api/billing/credit-notes")]
 [Authorize]
 [ApiController]
 public class CreditNotesController : ControllerBase

--- a/src/MyApp.Billing/MyApp.Billing.API/Controllers/InvoicesController.cs
+++ b/src/MyApp.Billing/MyApp.Billing.API/Controllers/InvoicesController.cs
@@ -2,16 +2,19 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MyApp.Billing.Application.Contracts.DTOs;
 using MyApp.Billing.Application.Contracts.Services;
+using MyApp.Billing.Domain.Specifications;
 using MyApp.Shared.Domain.Caching;
+using MyApp.Shared.Domain.Pagination;
 using MyApp.Shared.Domain.Permissions;
 using MyApp.Shared.Infrastructure.Export;
+using MyApp.Shared.Infrastructure.Extensions;
 
 namespace MyApp.Billing.API.Controllers;
 
 /// <summary>
 /// Manages billing invoices — creation, lifecycle transitions, payment recording and export.
 /// </summary>
-[Route("api/[controller]")]
+[Route("api/billing/invoices")]
 [Authorize]
 [ApiController]
 public class InvoicesController : ControllerBase
@@ -133,6 +136,42 @@ public class InvoicesController : ControllerBase
         {
             _logger.LogError(ex, "Error retrieving invoices for order {OrderId}", orderId);
             return StatusCode(StatusCodes.Status500InternalServerError, new { message = "An error occurred retrieving order invoices" });
+        }
+    }
+
+    /// <summary>
+    /// Searches invoices with filter, sort and pagination.
+    /// </summary>
+    [HttpGet("search")]
+    [HasPermission("Billing", "Read")]
+    [ProducesResponseType(typeof(PaginatedResult<InvoiceDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> Search([FromQuery] QuerySpec query, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+            return BadRequest(ModelState);
+
+        try
+        {
+            query.BindFiltersFromQuery(Request.Query);
+            query.Validate();
+
+            var spec = new InvoiceQuerySpec(query);
+            var result = await _invoiceService.QueryInvoicesAsync(spec, cancellationToken);
+
+            _logger.LogInformation("Searched invoices with query: {@Query}", query);
+            return Ok(result);
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogWarning(ex, "Invalid query specification for invoice search");
+            return BadRequest(new { message = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error searching invoices");
+            return StatusCode(StatusCodes.Status500InternalServerError, new { message = "An error occurred searching invoices" });
         }
     }
 

--- a/src/MyApp.Billing/MyApp.Billing.API/Controllers/PaymentsController.cs
+++ b/src/MyApp.Billing/MyApp.Billing.API/Controllers/PaymentsController.cs
@@ -10,7 +10,7 @@ namespace MyApp.Billing.API.Controllers;
 /// <summary>
 /// Read-only access to payment records associated with invoices.
 /// </summary>
-[Route("api/[controller]")]
+[Route("api/billing/payments")]
 [Authorize]
 [ApiController]
 public class PaymentsController : ControllerBase

--- a/src/MyApp.Billing/MyApp.Billing.Application.Contracts/DTOs/BillingDtos.cs
+++ b/src/MyApp.Billing/MyApp.Billing.Application.Contracts/DTOs/BillingDtos.cs
@@ -4,6 +4,7 @@ namespace MyApp.Billing.Application.Contracts.DTOs;
 /// DTO for creating an invoice from an order
 /// </summary>
 public record CreateInvoiceDto(
+    string InvoiceNumber, // Now required, not nullable
     Guid CustomerId,
     Guid? OrderId,
     string Currency,

--- a/src/MyApp.Billing/MyApp.Billing.Application.Contracts/Services/IInvoiceService.cs
+++ b/src/MyApp.Billing/MyApp.Billing.Application.Contracts/Services/IInvoiceService.cs
@@ -1,4 +1,7 @@
 using MyApp.Billing.Application.Contracts.DTOs;
+using MyApp.Billing.Domain.Entities;
+using MyApp.Shared.Domain.Pagination;
+using MyApp.Shared.Domain.Specifications;
 
 namespace MyApp.Billing.Application.Contracts.Services;
 
@@ -12,9 +15,11 @@ public interface IInvoiceService
     Task<InvoiceDto> RecordPaymentAsync(RecordPaymentDto dto, CancellationToken cancellationToken = default);
     Task<InvoiceDto> CancelInvoiceAsync(Guid invoiceId, string reason, CancellationToken cancellationToken = default);
     Task<CreditNoteDto> CreateCreditNoteAsync(CreateCreditNoteDto dto, CancellationToken cancellationToken = default);
-    
+
     Task<InvoiceDto?> GetInvoiceByIdAsync(Guid invoiceId, CancellationToken cancellationToken = default);
+    Task<InvoiceDto?> GetInvoiceByInvoiceNumberAsync(string invoiceNumber, CancellationToken cancellationToken = default);
     Task<List<InvoiceDto>> GetInvoicesByCustomerIdAsync(Guid customerId, CancellationToken cancellationToken = default);
     Task<List<InvoiceDto>> GetOpenInvoicesAsync(CancellationToken cancellationToken = default);
     Task<List<InvoiceDto>> GetInvoicesByOrderIdAsync(Guid orderId, CancellationToken cancellationToken = default);
+    Task<PaginatedResult<InvoiceDto>> QueryInvoicesAsync(ISpecification<Invoice> spec, CancellationToken cancellationToken = default);
 }

--- a/src/MyApp.Billing/MyApp.Billing.Application/Mapping/BillingMappingProfile.cs
+++ b/src/MyApp.Billing/MyApp.Billing.Application/Mapping/BillingMappingProfile.cs
@@ -17,13 +17,13 @@ public class BillingMappingProfile : Profile
     {
         CreateMap<Invoice, InvoiceDto>()
             .ForMember(d => d.Status, opt => opt.MapFrom(s => s.Status.ToString()));
-        
+
         CreateMap<CreditNote, CreditNoteDto>()
             .ForMember(d => d.Status, opt => opt.MapFrom(s => s.Status.ToString()));
 
         CreateMap<Payment, PaymentDto>()
             .ForMember(d => d.Status, opt => opt.MapFrom(s => s.Status.ToString()));
-        
+
         //CreateMap<CreditNoteLineData, CreditNoteLineDataDto>();
     }
 }

--- a/src/MyApp.Billing/MyApp.Billing.Application/Services/InvoiceService.cs
+++ b/src/MyApp.Billing/MyApp.Billing.Application/Services/InvoiceService.cs
@@ -6,6 +6,8 @@ using MyApp.Billing.Domain.Events;
 using MyApp.Billing.Domain.Repositories;
 using MyApp.Shared.Domain.Messaging;
 using MyApp.Shared.Domain.Exceptions;
+using MyApp.Shared.Domain.Pagination;
+using MyApp.Shared.Domain.Specifications;
 
 namespace MyApp.Billing.Application.Services;
 
@@ -39,8 +41,15 @@ public class InvoiceService : IInvoiceService
     /// </summary>
     public async Task<InvoiceDto> CreateInvoiceAsync(CreateInvoiceDto dto, CancellationToken cancellationToken = default)
     {
-        var invoice = new Invoice(Guid.NewGuid(), dto.CustomerId, dto.Currency);
-        
+        if (string.IsNullOrWhiteSpace(dto.InvoiceNumber))
+            throw new ArgumentException("InvoiceNumber must be a non-empty unique value.", nameof(dto.InvoiceNumber));
+
+        var existingInvoice = await _invoiceRepository.GetByInvoiceNumberAsync(dto.InvoiceNumber, cancellationToken);
+        if (existingInvoice is not null)
+            throw new InvalidOperationException($"Invoice number '{dto.InvoiceNumber}' already exists.");
+
+        var invoice = new Invoice(Guid.NewGuid(), dto.InvoiceNumber, dto.CustomerId, dto.Currency);
+
         foreach (var line in dto.Lines)
         {
             invoice.AddLine(line.Description, line.Quantity, line.UnitPrice, line.TaxRate, line.Discount);
@@ -65,11 +74,18 @@ public class InvoiceService : IInvoiceService
     /// </summary>
     public async Task<InvoiceDto> IssueInvoiceAsync(Guid invoiceId, string invoiceNumber, DateTime issueDate, CancellationToken cancellationToken = default)
     {
+        if (string.IsNullOrWhiteSpace(invoiceNumber))
+            throw new ArgumentException("InvoiceNumber must be a non-empty unique value.", nameof(invoiceNumber));
+
         var invoice = await _invoiceRepository.GetByIdAsync(invoiceId)
             ?? throw new NotFoundException($"Invoice {invoiceId} not found");
 
+        var existingInvoice = await _invoiceRepository.GetByInvoiceNumberAsync(invoiceNumber, cancellationToken);
+        if (existingInvoice is not null && existingInvoice.Id != invoiceId)
+            throw new InvalidOperationException($"Invoice number '{invoiceNumber}' already exists.");
+
         invoice.Issue(invoiceNumber, issueDate, invoice.PaymentTermsDays);
-        
+
         await _invoiceRepository.UpdateAsync(invoice);
 
         // Publish domain event
@@ -96,8 +112,8 @@ public class InvoiceService : IInvoiceService
             ?? throw new NotFoundException($"Invoice {dto.InvoiceId} not found");
 
         invoice.RecordPayment(dto.Amount, dto.Method, dto.PaidAt, dto.ExternalPaymentId);
-        
-        await _invoiceRepository.UpdateAsync(invoice);
+
+        await _invoiceRepository.SaveChangesAsync(cancellationToken);
 
         // Publish domain event
         await _eventPublisher.PublishAsync("billing.invoice.paid", new InvoicePaidEvent(
@@ -121,7 +137,7 @@ public class InvoiceService : IInvoiceService
             ?? throw new NotFoundException($"Invoice {invoiceId} not found");
 
         invoice.Cancel();
-        
+
         await _invoiceRepository.UpdateAsync(invoice);
 
         // Publish domain event
@@ -151,7 +167,7 @@ public class InvoiceService : IInvoiceService
         )).ToList();
 
         var creditNote = invoice.CreateCreditNote(lines, dto.Reason);
-        
+
         await _creditNoteRepository.AddAsync(creditNote);
 
         // Publish domain event
@@ -172,6 +188,15 @@ public class InvoiceService : IInvoiceService
     public async Task<InvoiceDto?> GetInvoiceByIdAsync(Guid invoiceId, CancellationToken cancellationToken = default)
     {
         var invoice = await _invoiceRepository.GetByIdAsync(invoiceId);
+        return invoice != null ? MapToDto(invoice) : null;
+    }
+
+    /// <summary>
+    /// Retrieves an invoice by its invoice number.
+    /// </summary>
+    public async Task<InvoiceDto?> GetInvoiceByInvoiceNumberAsync(string invoiceNumber, CancellationToken cancellationToken = default)
+    {
+        var invoice = await _invoiceRepository.GetByInvoiceNumberAsync(invoiceNumber, cancellationToken);
         return invoice != null ? MapToDto(invoice) : null;
     }
 
@@ -200,6 +225,16 @@ public class InvoiceService : IInvoiceService
     {
         var invoices = await _invoiceRepository.GetInvoicesByOrderIdAsync(orderId, cancellationToken);
         return invoices.Select(MapToDto).ToList();
+    }
+
+    /// <summary>
+    /// Queries invoices with filtering, sorting, and pagination.
+    /// </summary>
+    public async Task<PaginatedResult<InvoiceDto>> QueryInvoicesAsync(ISpecification<Invoice> spec, CancellationToken cancellationToken = default)
+    {
+        var result = await _invoiceRepository.QueryAsync(spec);
+        var invoices = result.Items.Select(MapToDto).ToList();
+        return new PaginatedResult<InvoiceDto>(invoices, result.PageNumber, result.PageSize, result.TotalCount);
     }
 
     private InvoiceDto MapToDto(Invoice invoice)

--- a/src/MyApp.Billing/MyApp.Billing.Domain/Entities/CreditNoteLine.cs
+++ b/src/MyApp.Billing/MyApp.Billing.Domain/Entities/CreditNoteLine.cs
@@ -16,7 +16,7 @@ public class CreditNoteLine : AuditableEntity<Guid>
         UnitPrice = unitPrice;
         TaxRate = taxRate;
         Discount = discount;
-        
+
         // Calculate line totals
         LineNet = quantity * unitPrice - discount;
         LineTax = LineNet * (taxRate / 100m);
@@ -29,7 +29,7 @@ public class CreditNoteLine : AuditableEntity<Guid>
     public decimal UnitPrice { get; private set; }
     public decimal Discount { get; private set; }
     public decimal TaxRate { get; private set; }
-    
+
     // Calculated totals
     public decimal LineNet { get; private set; }
     public decimal LineTax { get; private set; }

--- a/src/MyApp.Billing/MyApp.Billing.Domain/Entities/Invoice.cs
+++ b/src/MyApp.Billing/MyApp.Billing.Domain/Entities/Invoice.cs
@@ -7,8 +7,11 @@ namespace MyApp.Billing.Domain.Entities;
 /// </summary>
 public class Invoice : AuditableEntity<Guid>
 {
-    public Invoice(Guid id, Guid customerId, string currency) : base(id)
+    public Invoice(Guid id, string invoiceNumber, Guid customerId, string currency) : base(id)
     {
+        // Keep materialization/read paths resilient (legacy data may contain empty values).
+        // Create/issue flows enforce strict invoice-number validation at application/domain write boundaries.
+        InvoiceNumber = invoiceNumber ?? string.Empty;
         CustomerId = customerId;
         Currency = currency;
         Status = InvoiceStatus.Draft;
@@ -17,7 +20,7 @@ public class Invoice : AuditableEntity<Guid>
     }
 
     // Basic info
-    public string InvoiceNumber { get; private set; } = string.Empty;
+    public string InvoiceNumber { get; private set; }
     public Guid CustomerId { get; private set; }
     public Guid? OrderId { get; private set; }
     public string Currency { get; private set; }
@@ -61,6 +64,9 @@ public class Invoice : AuditableEntity<Guid>
     {
         if (Status != InvoiceStatus.Draft)
             throw new InvalidOperationException("Only draft invoices can be issued.");
+
+        if (string.IsNullOrWhiteSpace(invoiceNumber))
+            throw new ArgumentException("InvoiceNumber must be a non-empty unique value.", nameof(invoiceNumber));
 
         if (Lines.Count == 0)
             throw new InvalidOperationException("Cannot issue invoice without lines.");
@@ -120,7 +126,7 @@ public class Invoice : AuditableEntity<Guid>
 
         var creditNote = new CreditNote(Guid.NewGuid(), Id, lines, reason);
         CreditNotes.Add(creditNote);
-        
+
         // Adjust outstanding amount
         foreach (var line in lines)
         {

--- a/src/MyApp.Billing/MyApp.Billing.Domain/Entities/InvoiceLine.cs
+++ b/src/MyApp.Billing/MyApp.Billing.Domain/Entities/InvoiceLine.cs
@@ -16,7 +16,7 @@ public class InvoiceLine : AuditableEntity<Guid>
         UnitPrice = unitPrice;
         TaxRate = taxRate;
         Discount = discount;
-        
+
         // Calculate line totals
         LineNet = quantity * unitPrice - discount;
         LineTax = LineNet * (taxRate / 100m);
@@ -29,7 +29,7 @@ public class InvoiceLine : AuditableEntity<Guid>
     public decimal UnitPrice { get; private set; }
     public decimal Discount { get; private set; }
     public decimal TaxRate { get; private set; }
-    
+
     // Calculated totals
     public decimal LineNet { get; private set; }
     public decimal LineTax { get; private set; }

--- a/src/MyApp.Billing/MyApp.Billing.Domain/Repositories/BillingRepositories.cs
+++ b/src/MyApp.Billing/MyApp.Billing.Domain/Repositories/BillingRepositories.cs
@@ -12,6 +12,7 @@ public interface IInvoiceRepository : IRepository<Invoice, Guid>
     Task<List<Invoice>> GetByCustomerIdAsync(Guid customerId, CancellationToken cancellationToken = default);
     Task<List<Invoice>> GetOpenInvoicesAsync(CancellationToken cancellationToken = default);
     Task<List<Invoice>> GetInvoicesByOrderIdAsync(Guid orderId, CancellationToken cancellationToken = default);
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/src/MyApp.Billing/MyApp.Billing.Domain/Specifications/InvoiceQuerySpec.cs
+++ b/src/MyApp.Billing/MyApp.Billing.Domain/Specifications/InvoiceQuerySpec.cs
@@ -1,0 +1,107 @@
+using MyApp.Billing.Domain.Entities;
+using MyApp.Shared.Domain.Pagination;
+using MyApp.Shared.Domain.Specifications;
+
+namespace MyApp.Billing.Domain.Specifications;
+
+/// <summary>
+/// Specification for querying invoices with filtering, sorting, and pagination.
+/// </summary>
+public class InvoiceQuerySpec : BaseSpecification<Invoice>
+{
+    public InvoiceQuerySpec(QuerySpec query) : base(query) { }
+
+    public override IQueryable<Invoice> ApplyFilters(IQueryable<Invoice> query)
+    {
+        if (Query.Filters?.TryGetValue(nameof(Invoice.InvoiceNumber), out var invoiceNumberFilter) == true
+            && !string.IsNullOrWhiteSpace(invoiceNumberFilter))
+        {
+            var term = invoiceNumberFilter.Trim().ToLower();
+            query = query.Where(i => i.InvoiceNumber.ToLower().Contains(term));
+        }
+
+        if (Query.Filters?.TryGetValue(nameof(Invoice.CustomerId), out var customerIdFilter) == true
+            && Guid.TryParse(customerIdFilter, out var customerId))
+        {
+            query = query.Where(i => i.CustomerId == customerId);
+        }
+
+        if (Query.Filters?.TryGetValue(nameof(Invoice.OrderId), out var orderIdFilter) == true
+            && Guid.TryParse(orderIdFilter, out var orderId))
+        {
+            query = query.Where(i => i.OrderId == orderId);
+        }
+
+        if (Query.Filters?.TryGetValue(nameof(Invoice.Currency), out var currencyFilter) == true
+            && !string.IsNullOrWhiteSpace(currencyFilter))
+        {
+            var currency = currencyFilter.Trim().ToUpper();
+            query = query.Where(i => i.Currency == currency);
+        }
+
+        if (Query.Filters?.TryGetValue(nameof(Invoice.Status), out var statusFilter) == true
+            && Enum.TryParse<InvoiceStatus>(statusFilter, true, out var status))
+        {
+            query = query.Where(i => i.Status == status);
+        }
+
+        if (Query.Filters?.TryGetValue("IssueDateFrom", out var issueDateFromFilter) == true
+            && DateTime.TryParse(issueDateFromFilter, out var issueDateFrom))
+        {
+            query = query.Where(i => i.IssueDate.HasValue && i.IssueDate.Value >= issueDateFrom);
+        }
+
+        if (Query.Filters?.TryGetValue("IssueDateTo", out var issueDateToFilter) == true
+            && DateTime.TryParse(issueDateToFilter, out var issueDateTo))
+        {
+            query = query.Where(i => i.IssueDate.HasValue && i.IssueDate.Value <= issueDateTo);
+        }
+
+        if (Query.Filters?.TryGetValue("DueDateFrom", out var dueDateFromFilter) == true
+            && DateTime.TryParse(dueDateFromFilter, out var dueDateFrom))
+        {
+            query = query.Where(i => i.DueDate.HasValue && i.DueDate.Value >= dueDateFrom);
+        }
+
+        if (Query.Filters?.TryGetValue("DueDateTo", out var dueDateToFilter) == true
+            && DateTime.TryParse(dueDateToFilter, out var dueDateTo))
+        {
+            query = query.Where(i => i.DueDate.HasValue && i.DueDate.Value <= dueDateTo);
+        }
+
+        if (Query.Filters?.TryGetValue("OutstandingAmountMin", out var outstandingMinFilter) == true
+            && decimal.TryParse(outstandingMinFilter, out var outstandingMin))
+        {
+            query = query.Where(i => i.OutstandingAmount >= outstandingMin);
+        }
+
+        if (Query.Filters?.TryGetValue("OutstandingAmountMax", out var outstandingMaxFilter) == true
+            && decimal.TryParse(outstandingMaxFilter, out var outstandingMax))
+        {
+            query = query.Where(i => i.OutstandingAmount <= outstandingMax);
+        }
+
+        if (Query.Filters?.TryGetValue("TotalGrossMin", out var totalGrossMinFilter) == true
+            && decimal.TryParse(totalGrossMinFilter, out var totalGrossMin))
+        {
+            query = query.Where(i => i.TotalGross >= totalGrossMin);
+        }
+
+        if (Query.Filters?.TryGetValue("TotalGrossMax", out var totalGrossMaxFilter) == true
+            && decimal.TryParse(totalGrossMaxFilter, out var totalGrossMax))
+        {
+            query = query.Where(i => i.TotalGross <= totalGrossMax);
+        }
+
+        if (!string.IsNullOrWhiteSpace(Query.SearchTerm))
+        {
+            var searchTerm = Query.SearchTerm.Trim().ToLower();
+            query = query.Where(i =>
+                i.InvoiceNumber.ToLower().Contains(searchTerm) ||
+                i.Currency.ToLower().Contains(searchTerm) ||
+                i.Status.ToString().ToLower().Contains(searchTerm));
+        }
+
+        return query;
+    }
+}

--- a/src/MyApp.Billing/MyApp.Billing.Infrastructure/Repositories/BillingRepositories.cs
+++ b/src/MyApp.Billing/MyApp.Billing.Infrastructure/Repositories/BillingRepositories.cs
@@ -2,6 +2,8 @@ using Microsoft.EntityFrameworkCore;
 using MyApp.Billing.Domain.Entities;
 using MyApp.Billing.Domain.Repositories;
 using MyApp.Billing.Infrastructure.Persistence;
+using MyApp.Shared.Domain.Pagination;
+using MyApp.Shared.Domain.Specifications;
 using MyApp.Shared.Infrastructure.Repositories;
 
 namespace MyApp.Billing.Infrastructure.Repositories;
@@ -11,6 +13,17 @@ namespace MyApp.Billing.Infrastructure.Repositories;
 /// </summary>
 public class InvoiceRepository : Repository<Invoice, Guid>, IInvoiceRepository
 {
+    /// <summary>
+    /// Retrieves an invoice by its identifier with related lines and payments loaded.
+    /// </summary>
+    public override async Task<Invoice?> GetByIdAsync(Guid id)
+    {
+        return await _context.Invoices
+            .Include(i => i.Lines)
+            .Include(i => i.Payments)
+            .FirstOrDefaultAsync(i => i.Id == id);
+    }
+
     private readonly BillingDbContext _context;
 
     /// <summary>
@@ -64,6 +77,64 @@ public class InvoiceRepository : Repository<Invoice, Guid>, IInvoiceRepository
             .Include(i => i.Lines)
             .Where(i => i.OrderId == orderId)
             .ToListAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Persists pending changes for tracked invoice aggregates.
+    /// </summary>
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        // When payments are appended through the Invoice aggregate, EF can occasionally
+        // track new Payment rows as Modified instead of Added in this graph path.
+        // Correct that state before SaveChanges to avoid false concurrency exceptions.
+        var paymentEntries = _context.ChangeTracker.Entries<Payment>()
+            .Where(e => e.State == EntityState.Modified)
+            .ToList();
+
+        foreach (var entry in paymentEntries)
+        {
+            var paymentId = entry.Entity.Id;
+            var exists = await _context.Payments
+                .AsNoTracking()
+                .AnyAsync(p => p.Id == paymentId, cancellationToken);
+
+            if (!exists)
+            {
+                entry.State = EntityState.Added;
+            }
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Queries invoices using specification with lines included.
+    /// </summary>
+    public override async Task<PaginatedResult<Invoice>> QueryAsync(ISpecification<Invoice> spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+
+        var baseQuery = _context.Invoices
+            .Include(i => i.Lines)
+            .AsNoTracking()
+            .AsQueryable();
+
+        var filteredQuery = spec.ApplyFilters(baseQuery);
+        var totalCount = await filteredQuery.CountAsync();
+
+        var finalQuery = spec.Apply(baseQuery);
+        var items = await finalQuery.ToListAsync();
+
+        var pageNumber = 1;
+        var pageSize = items.Count;
+
+        if (spec is BaseSpecification<Invoice> baseSpec)
+        {
+            pageNumber = baseSpec.Query.Page;
+            pageSize = baseSpec.Query.PageSize;
+        }
+
+        return new PaginatedResult<Invoice>(items, pageNumber, pageSize, totalCount);
     }
 }
 

--- a/src/MyApp.Billing/test/MyApp.Billing.API.Tests/Controllers/InvoicesControllerTests.cs
+++ b/src/MyApp.Billing/test/MyApp.Billing.API.Tests/Controllers/InvoicesControllerTests.cs
@@ -6,8 +6,11 @@ using Moq;
 using MyApp.Billing.API.Controllers;
 using MyApp.Billing.Application.Contracts.DTOs;
 using MyApp.Billing.Application.Contracts.Services;
+using MyApp.Billing.Domain.Entities;
+using MyApp.Shared.Domain.Pagination;
 using MyApp.Shared.Domain.Caching;
 using MyApp.Shared.Domain.Exceptions;
+using MyApp.Shared.Domain.Specifications;
 using Xunit;
 
 namespace MyApp.Billing.API.Tests.Controllers;
@@ -251,14 +254,85 @@ public class InvoicesControllerTests
         _invoiceService.Verify(s => s.GetInvoicesByOrderIdAsync(orderId, It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    // ─── Search ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Search_ValidQuery_ReturnsPaginatedResult()
+    {
+        // Arrange
+        _sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        _sut.HttpContext.Request.QueryString = new QueryString("?searchTerm=INV&page=1&pageSize=20");
+
+        var query = new QuerySpec { Page = 1, PageSize = 20, SearchTerm = "INV" };
+        var paginated = new PaginatedResult<InvoiceDto>(SampleInvoiceList(2), 1, 20, 2);
+        _invoiceService.Setup(s => s.QueryInvoicesAsync(It.IsAny<ISpecification<Invoice>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(paginated);
+
+        // Act
+        var result = await _sut.Search(query, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<OkObjectResult>()
+            .Which.Value.Should().BeSameAs(paginated);
+        _invoiceService.Verify(s => s.QueryInvoicesAsync(It.IsAny<ISpecification<Invoice>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Search_InvalidModel_ReturnsBadRequest()
+    {
+        // Arrange
+        _sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        var query = new QuerySpec();
+        _sut.ModelState.AddModelError("Page", "Invalid page");
+
+        // Act
+        var result = await _sut.Search(query, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+        _invoiceService.Verify(s => s.QueryInvoicesAsync(It.IsAny<ISpecification<Invoice>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Search_InvalidQuerySpec_ReturnsBadRequest()
+    {
+        // Arrange
+        _sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        _sut.HttpContext.Request.QueryString = new QueryString("?page=1&pageSize=20");
+
+        var query = new QuerySpec();
+        _invoiceService.Setup(s => s.QueryInvoicesAsync(It.IsAny<ISpecification<Invoice>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ArgumentException("Invalid query"));
+
+        // Act
+        var result = await _sut.Search(query, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
     // ─── Create ───────────────────────────────────────────────────────────────
 
     [Fact]
     public async Task Create_ValidDto_Returns201Created()
     {
         // Arrange
-        var dto = new CreateInvoiceDto(Guid.NewGuid(), null, "USD",
-            new List<CreateInvoiceLineDto> { new("Item", 1, 100m, 10m, 0m) }, 30);
+        var dto = new CreateInvoiceDto(
+            "INV-TEST-" + Guid.NewGuid().ToString()[..8], // InvoiceNumber
+            Guid.NewGuid(),
+            null,
+            "USD",
+            new List<CreateInvoiceLineDto> { new("Item", 1, 100m, 10m, 0m) },
+            30);
         var created = SampleInvoiceDto("Draft");
         _invoiceService.Setup(s => s.CreateInvoiceAsync(dto, It.IsAny<CancellationToken>()))
                        .ReturnsAsync(created);
@@ -277,7 +351,13 @@ public class InvoicesControllerTests
     public async Task Create_InvalidModel_Returns400()
     {
         // Arrange
-        var dto = new CreateInvoiceDto(Guid.NewGuid(), null, "USD", new List<CreateInvoiceLineDto>(), 30);
+        var dto = new CreateInvoiceDto(
+            "asd", // InvoiceNumber
+            Guid.NewGuid(),
+            null,
+            "USD",
+            new List<CreateInvoiceLineDto>(),
+            30);
         _sut.ModelState.AddModelError("Lines", "At least one line required");
 
         // Act
@@ -292,8 +372,13 @@ public class InvoicesControllerTests
     public async Task Create_ServiceThrowsInvalidOperation_Returns400()
     {
         // Arrange
-        var dto = new CreateInvoiceDto(Guid.NewGuid(), null, "USD",
-            new List<CreateInvoiceLineDto> { new("Item", 1, 100m, 10m, 0m) }, 30);
+        var dto = new CreateInvoiceDto(
+            "INV-TEST-" + Guid.NewGuid().ToString()[..8], // InvoiceNumber
+            Guid.NewGuid(),
+            null,
+            "USD",
+            new List<CreateInvoiceLineDto> { new("Item", 1, 100m, 10m, 0m) },
+            30);
         _invoiceService.Setup(s => s.CreateInvoiceAsync(dto, It.IsAny<CancellationToken>()))
                        .ThrowsAsync(new InvalidOperationException("Customer blocked"));
 
@@ -308,8 +393,13 @@ public class InvoicesControllerTests
     public async Task Create_InvalidatesOpenInvoicesCache()
     {
         // Arrange
-        var dto = new CreateInvoiceDto(Guid.NewGuid(), null, "USD",
-            new List<CreateInvoiceLineDto> { new("Item", 1, 100m, 10m, 0m) }, 30);
+        var dto = new CreateInvoiceDto(
+            "INV-TEST-" + Guid.NewGuid().ToString()[..8], // InvoiceNumber
+            Guid.NewGuid(),
+            null,
+            "USD",
+            new List<CreateInvoiceLineDto> { new("Item", 1, 100m, 10m, 0m) },
+            30);
         _invoiceService.Setup(s => s.CreateInvoiceAsync(dto, It.IsAny<CancellationToken>()))
                        .ReturnsAsync(SampleInvoiceDto("Draft"));
         _cacheService.Setup(c => c.RemoveStateAsync(It.IsAny<string>())).Returns(Task.CompletedTask);

--- a/src/MyApp.Billing/test/MyApp.Billing.Application.Tests/Services/InvoiceServiceTests.cs
+++ b/src/MyApp.Billing/test/MyApp.Billing.Application.Tests/Services/InvoiceServiceTests.cs
@@ -5,8 +5,10 @@ using MyApp.Billing.Application.Contracts.DTOs;
 using MyApp.Billing.Application.Services;
 using MyApp.Billing.Domain.Entities;
 using MyApp.Billing.Domain.Repositories;
+using MyApp.Billing.Domain.Specifications;
 using MyApp.Shared.Domain.Exceptions;
 using MyApp.Shared.Domain.Messaging;
+using MyApp.Shared.Domain.Pagination;
 using Xunit;
 
 namespace MyApp.Billing.Application.Tests.Services;
@@ -37,7 +39,7 @@ public class InvoiceServiceTests
 
     private static Invoice BuildDraftInvoice(Guid? customerId = null)
     {
-        var inv = new Invoice(Guid.NewGuid(), customerId ?? Guid.NewGuid(), "USD");
+        var inv = new Invoice(Guid.NewGuid(), $"INV-DRAFT-{Guid.NewGuid().ToString()[..8]}", customerId ?? Guid.NewGuid(), "USD");
         inv.AddLine("Widget", 2, 50m, 10m);
         return inv;
     }
@@ -51,6 +53,7 @@ public class InvoiceServiceTests
 
     private static CreateInvoiceDto SampleCreateDto(int lineCount = 1) =>
         new(
+            $"INV-TEST-{Guid.NewGuid().ToString()[..8]}", // Always a valid, unique InvoiceNumber
             CustomerId: Guid.NewGuid(),
             OrderId: null,
             Currency: "USD",
@@ -66,6 +69,8 @@ public class InvoiceServiceTests
     {
         // Arrange
         var dto = SampleCreateDto(2);
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync(dto.InvoiceNumber, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync((Invoice?)null);
         _invoiceRepo.Setup(r => r.AddAsync(It.IsAny<Invoice>())).Returns<Invoice>(i => Task.FromResult(i));
         _eventPublisher.Setup(e => e.PublishAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                        .Returns(Task.CompletedTask);
@@ -92,6 +97,8 @@ public class InvoiceServiceTests
     {
         // Arrange
         var dto = SampleCreateDto();
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync(dto.InvoiceNumber, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync((Invoice?)null);
         _invoiceRepo.Setup(r => r.AddAsync(It.IsAny<Invoice>())).Returns<Invoice>(i => Task.FromResult(i));
         _eventPublisher.Setup(e => e.PublishAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                        .Returns(Task.CompletedTask);
@@ -111,8 +118,15 @@ public class InvoiceServiceTests
     {
         // Arrange
         var orderId = Guid.NewGuid();
-        var dto = new CreateInvoiceDto(Guid.NewGuid(), orderId, "EUR",
-            new List<CreateInvoiceLineDto> { new("Product A", 1, 200m, 20m, 0m) }, 14);
+        var dto = new CreateInvoiceDto(
+            "123", // InvoiceNumber
+            Guid.NewGuid(),
+            orderId,
+            "EUR",
+            new List<CreateInvoiceLineDto> { new("Product A", 1, 200m, 20m, 0m) },
+            14);
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync(dto.InvoiceNumber, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync((Invoice?)null);
         _invoiceRepo.Setup(r => r.AddAsync(It.IsAny<Invoice>())).Returns<Invoice>(i => Task.FromResult(i));
         _eventPublisher.Setup(e => e.PublishAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                        .Returns(Task.CompletedTask);
@@ -124,6 +138,24 @@ public class InvoiceServiceTests
         result.Currency.Should().Be("EUR");
     }
 
+    [Fact]
+    public async Task CreateInvoiceAsync_DuplicateInvoiceNumber_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var dto = SampleCreateDto();
+        var existingInvoice = BuildDraftInvoice();
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync(dto.InvoiceNumber, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingInvoice);
+
+        // Act
+        Func<Task> act = () => _sut.CreateInvoiceAsync(dto);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*{dto.InvoiceNumber}*");
+        _invoiceRepo.Verify(r => r.AddAsync(It.IsAny<Invoice>()), Times.Never);
+    }
+
     // ─── IssueInvoiceAsync ───────────────────────────────────────────────────
 
     [Fact]
@@ -133,6 +165,8 @@ public class InvoiceServiceTests
         var invoice = BuildDraftInvoice();
         var issueDate = DateTime.UtcNow;
         _invoiceRepo.Setup(r => r.GetByIdAsync(invoice.Id)).ReturnsAsync(invoice);
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync("INV-100", It.IsAny<CancellationToken>()))
+                    .ReturnsAsync((Invoice?)null);
         _invoiceRepo.Setup(r => r.UpdateAsync(It.IsAny<Invoice>())).Returns<Invoice>(i => Task.FromResult(i));
         _eventPublisher.Setup(e => e.PublishAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                        .Returns(Task.CompletedTask);
@@ -167,6 +201,8 @@ public class InvoiceServiceTests
         // Arrange
         var invoice = BuildDraftInvoice();
         _invoiceRepo.Setup(r => r.GetByIdAsync(invoice.Id)).ReturnsAsync(invoice);
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync("INV-200", It.IsAny<CancellationToken>()))
+                    .ReturnsAsync((Invoice?)null);
         _invoiceRepo.Setup(r => r.UpdateAsync(It.IsAny<Invoice>())).Returns<Invoice>(i => Task.FromResult(i));
         _eventPublisher.Setup(e => e.PublishAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                        .Returns(Task.CompletedTask);
@@ -187,6 +223,8 @@ public class InvoiceServiceTests
         // Arrange
         var invoice = BuildDraftInvoice();
         _invoiceRepo.Setup(r => r.GetByIdAsync(invoice.Id)).ReturnsAsync(invoice);
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync("INV-300", It.IsAny<CancellationToken>()))
+                    .ReturnsAsync((Invoice?)null);
         _invoiceRepo.Setup(r => r.UpdateAsync(It.IsAny<Invoice>())).Returns<Invoice>(i => Task.FromResult(i));
         _eventPublisher.Setup(e => e.PublishAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                        .Returns(Task.CompletedTask);
@@ -200,6 +238,26 @@ public class InvoiceServiceTests
             i.InvoiceNumber == "INV-300")), Times.Once);
     }
 
+    [Fact]
+    public async Task IssueInvoiceAsync_DuplicateInvoiceNumberUsedByAnotherInvoice_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var invoice = BuildDraftInvoice();
+        var conflictingInvoice = BuildDraftInvoice();
+        const string duplicateNumber = "INV-DUPLICATE-001";
+        _invoiceRepo.Setup(r => r.GetByIdAsync(invoice.Id)).ReturnsAsync(invoice);
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync(duplicateNumber, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(conflictingInvoice);
+
+        // Act
+        Func<Task> act = () => _sut.IssueInvoiceAsync(invoice.Id, duplicateNumber, DateTime.UtcNow);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*{duplicateNumber}*");
+        _invoiceRepo.Verify(r => r.UpdateAsync(It.IsAny<Invoice>()), Times.Never);
+    }
+
     // ─── RecordPaymentAsync ──────────────────────────────────────────────────
 
     [Fact]
@@ -209,7 +267,7 @@ public class InvoiceServiceTests
         var invoice = BuildIssuedInvoice();
         var dto = new RecordPaymentDto(invoice.Id, invoice.TotalGross, "BankTransfer", DateTime.UtcNow);
         _invoiceRepo.Setup(r => r.GetByIdAsync(invoice.Id)).ReturnsAsync(invoice);
-        _invoiceRepo.Setup(r => r.UpdateAsync(It.IsAny<Invoice>())).Returns<Invoice>(i => Task.FromResult(i));
+        _invoiceRepo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
         _eventPublisher.Setup(e => e.PublishAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                        .Returns(Task.CompletedTask);
 
@@ -230,7 +288,7 @@ public class InvoiceServiceTests
         var partialAmount = invoice.TotalGross / 2;
         var dto = new RecordPaymentDto(invoice.Id, partialAmount, "Card", DateTime.UtcNow);
         _invoiceRepo.Setup(r => r.GetByIdAsync(invoice.Id)).ReturnsAsync(invoice);
-        _invoiceRepo.Setup(r => r.UpdateAsync(It.IsAny<Invoice>())).Returns<Invoice>(i => Task.FromResult(i));
+        _invoiceRepo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
         _eventPublisher.Setup(e => e.PublishAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                        .Returns(Task.CompletedTask);
 
@@ -265,7 +323,7 @@ public class InvoiceServiceTests
         var invoice = BuildIssuedInvoice();
         var dto = new RecordPaymentDto(invoice.Id, invoice.TotalGross, "BankTransfer", DateTime.UtcNow);
         _invoiceRepo.Setup(r => r.GetByIdAsync(invoice.Id)).ReturnsAsync(invoice);
-        _invoiceRepo.Setup(r => r.UpdateAsync(It.IsAny<Invoice>())).Returns<Invoice>(i => Task.FromResult(i));
+        _invoiceRepo.Setup(r => r.SaveChangesAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
         _eventPublisher.Setup(e => e.PublishAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                        .Returns(Task.CompletedTask);
 
@@ -504,6 +562,38 @@ public class InvoiceServiceTests
         result.Should().BeNull();
     }
 
+    [Fact]
+    public async Task GetInvoiceByInvoiceNumberAsync_ExistingNumber_ReturnsDto()
+    {
+        // Arrange
+        var invoice = BuildIssuedInvoice();
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync(invoice.InvoiceNumber, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invoice);
+
+        // Act
+        var result = await _sut.GetInvoiceByInvoiceNumberAsync(invoice.InvoiceNumber);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.InvoiceNumber.Should().Be(invoice.InvoiceNumber);
+        result.Id.Should().Be(invoice.Id);
+    }
+
+    [Fact]
+    public async Task GetInvoiceByInvoiceNumberAsync_UnknownNumber_ReturnsNull()
+    {
+        // Arrange
+        const string unknownInvoiceNumber = "INV-UNKNOWN-123";
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync(unknownInvoiceNumber, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Invoice?)null);
+
+        // Act
+        var result = await _sut.GetInvoiceByInvoiceNumberAsync(unknownInvoiceNumber);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
     // ─── GetInvoicesByCustomerIdAsync ────────────────────────────────────────
 
     [Fact]
@@ -513,8 +603,8 @@ public class InvoiceServiceTests
         var customerId = Guid.NewGuid();
         var invoices = new List<Invoice>
         {
-            new Invoice(Guid.NewGuid(), customerId, "USD"),
-            new Invoice(Guid.NewGuid(), customerId, "EUR"),
+            new Invoice(Guid.NewGuid(), $"INV-CUST-{Guid.NewGuid().ToString()[..8]}", customerId, "USD"),
+            new Invoice(Guid.NewGuid(), $"INV-CUST-{Guid.NewGuid().ToString()[..8]}", customerId, "EUR"),
         };
         _invoiceRepo.Setup(r => r.GetByCustomerIdAsync(customerId, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(invoices);
@@ -612,6 +702,26 @@ public class InvoiceServiceTests
         result.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task QueryInvoicesAsync_ReturnsPaginatedMappedDtos()
+    {
+        // Arrange
+        var invoices = new List<Invoice> { BuildIssuedInvoice(), BuildIssuedInvoice() };
+        var spec = new InvoiceQuerySpec(new QuerySpec { Page = 1, PageSize = 10 });
+        var paged = new PaginatedResult<Invoice>(invoices, 1, 10, 2);
+        _invoiceRepo.Setup(r => r.QueryAsync(spec)).ReturnsAsync(paged);
+
+        // Act
+        var result = await _sut.QueryInvoicesAsync(spec);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.PageNumber.Should().Be(1);
+        result.PageSize.Should().Be(10);
+        result.TotalCount.Should().Be(2);
+        result.Items.Should().HaveCount(2);
+    }
+
     // ─── DTO mapping ─────────────────────────────────────────────────────────
 
     [Fact]
@@ -619,8 +729,15 @@ public class InvoiceServiceTests
     {
         // Arrange – 1 line: qty 2, price 100, tax 10%, discount 0
         // LineNet = 200, LineTax = 20, LineGross = 220
-        var dto = new CreateInvoiceDto(Guid.NewGuid(), null, "USD",
-            new List<CreateInvoiceLineDto> { new("Widget", 2, 100m, 10m, 0m) }, 30);
+        var dto = new CreateInvoiceDto(
+            "432", // InvoiceNumber
+            Guid.NewGuid(),
+            null,
+            "USD",
+            new List<CreateInvoiceLineDto> { new("Widget", 2, 100m, 10m, 0m) },
+            30);
+        _invoiceRepo.Setup(r => r.GetByInvoiceNumberAsync(dto.InvoiceNumber, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync((Invoice?)null);
         _invoiceRepo.Setup(r => r.AddAsync(It.IsAny<Invoice>())).Returns<Invoice>(i => Task.FromResult(i));
         _eventPublisher.Setup(e => e.PublishAsync(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
                        .Returns(Task.CompletedTask);
@@ -656,4 +773,5 @@ public class InvoiceServiceTests
         result.DueDate.Should().NotBeNull();
         result.Lines.Should().HaveCount(1);
     }
+
 }

--- a/src/MyApp.Billing/test/MyApp.Billing.Infrastructure.Tests/Repositories/CreditNoteRepositoryTests.cs
+++ b/src/MyApp.Billing/test/MyApp.Billing.Infrastructure.Tests/Repositories/CreditNoteRepositoryTests.cs
@@ -23,7 +23,7 @@ public class CreditNoteRepositoryTests
     /// <summary>Seeds a persisted issued invoice so credit notes can reference a valid FK.</summary>
     private Invoice SeedIssuedInvoice(string? invoiceNumber = null)
     {
-        var inv = new Invoice(Guid.NewGuid(), Guid.NewGuid(), "USD");
+        var inv = new Invoice(Guid.NewGuid(), $"INV-CN-{Guid.NewGuid().ToString()[..8]}", Guid.NewGuid(), "USD");
         inv.AddLine("Widget", 2, 100m, 10m);
         inv.Issue(invoiceNumber ?? $"INV-{Guid.NewGuid().ToString()[..8]}", DateTime.UtcNow, 30);
         _context.Invoices.Add(inv);

--- a/src/MyApp.Billing/test/MyApp.Billing.Infrastructure.Tests/Repositories/InvoiceRepositoryTests.cs
+++ b/src/MyApp.Billing/test/MyApp.Billing.Infrastructure.Tests/Repositories/InvoiceRepositoryTests.cs
@@ -22,9 +22,9 @@ public class InvoiceRepositoryTests
     // ─── factory helpers ──────────────────────────────────────────────────────
 
     private Invoice CreateDraftInvoice(Guid? customerId = null, Guid? orderId = null,
-        string currency = "USD", string invoiceNumber = "")
+        string currency = "USD", string invoiceNumber = "INV-TEST-DRAFT")
     {
-        var inv = new Invoice(Guid.NewGuid(), customerId ?? Guid.NewGuid(), currency);
+        var inv = new Invoice(Guid.NewGuid(), invoiceNumber, customerId ?? Guid.NewGuid(), currency);
         inv.AddLine("Widget", 2, 50m, 10m);
         _context.Invoices.Add(inv);
         _context.SaveChanges();
@@ -34,7 +34,7 @@ public class InvoiceRepositoryTests
     private Invoice CreateIssuedInvoice(Guid? customerId = null, Guid? orderId = null,
         string invoiceNumber = "INV-001", int dueDays = 30)
     {
-        var inv = new Invoice(Guid.NewGuid(), customerId ?? Guid.NewGuid(), "USD");
+        var inv = new Invoice(Guid.NewGuid(), $"INV-BYORDER-{Guid.NewGuid().ToString()[..8]}", customerId ?? Guid.NewGuid(), "USD");
         inv.AddLine("Widget", 2, 50m, 10m);
         inv.Issue(invoiceNumber, DateTime.UtcNow, dueDays);
         _context.Invoices.Add(inv);
@@ -139,13 +139,13 @@ public class InvoiceRepositoryTests
 
         // AuditableDbContext only overrides SaveChangesAsync; the helper calls the sync
         // variant, so CreatedAt stays at DateTime.MinValue unless we set it explicitly.
-        var inv1 = new Invoice(Guid.NewGuid(), customerId, "USD");
+        var inv1 = new Invoice(Guid.NewGuid(), "INV-ORDER-1", customerId, "USD");
         inv1.AddLine("Widget", 2, 50m, 10m);
         inv1.CreatedAt = DateTime.UtcNow.AddSeconds(-10);
         _context.Invoices.Add(inv1);
         _context.SaveChanges();
 
-        var inv2 = new Invoice(Guid.NewGuid(), customerId, "USD");
+        var inv2 = new Invoice(Guid.NewGuid(), "INV-ORDER-2", customerId, "USD");
         inv2.AddLine("Widget", 2, 50m, 10m);
         inv2.CreatedAt = DateTime.UtcNow;
         _context.Invoices.Add(inv2);
@@ -273,7 +273,7 @@ public class InvoiceRepositoryTests
     [Fact]
     public async Task AddAsync_PersistsInvoice()
     {
-        var inv = new Invoice(Guid.NewGuid(), Guid.NewGuid(), "EUR");
+        var inv = new Invoice(Guid.NewGuid(), $"INV-ADD-{Guid.NewGuid().ToString()[..8]}", Guid.NewGuid(), "EUR");
         inv.AddLine("Product A", 1, 100m, 10m);
 
         await _repository.AddAsync(inv);
@@ -286,7 +286,7 @@ public class InvoiceRepositoryTests
     [Fact]
     public async Task AddAsync_SetsAuditFields()
     {
-        var inv = new Invoice(Guid.NewGuid(), Guid.NewGuid(), "USD");
+        var inv = new Invoice(Guid.NewGuid(), $"INV-AUDIT-{Guid.NewGuid().ToString()[..8]}", Guid.NewGuid(), "USD");
         inv.AddLine("X", 1, 10m, 0m);
 
         await _repository.AddAsync(inv);
@@ -325,12 +325,34 @@ public class InvoiceRepositoryTests
         stored!.OutstandingAmount.Should().Be(gross - gross / 2);
     }
 
+    [Fact]
+    public async Task SaveChangesAsync_RecordPaymentGraph_PersistsNewPaymentWithoutManualStateFix()
+    {
+        // Arrange
+        var inv = CreateIssuedInvoice(invoiceNumber: "INV-SAVE-001");
+        var gross = inv.TotalGross;
+        inv.RecordPayment(10m, "Card", DateTime.UtcNow);
+
+        // Act
+        await _repository.SaveChangesAsync();
+
+        // Assert
+        var paymentCount = await _context.Payments.CountAsync(p => p.InvoiceId == inv.Id);
+        paymentCount.Should().Be(1);
+
+        var stored = await _context.Invoices.FindAsync(inv.Id);
+        stored!.OutstandingAmount.Should().Be(gross - 10m);
+    }
+
     // ─── DeleteAsync ──────────────────────────────────────────────────────────
 
     [Fact]
     public async Task DeleteAsync_RemovesInvoice()
     {
-        var inv = CreateDraftInvoice();
+        var inv = new Invoice(Guid.NewGuid(), $"INV-DEL-{Guid.NewGuid().ToString()[..8]}", Guid.NewGuid(), "USD");
+        inv.AddLine("Widget", 2, 50m, 10m);
+        _context.Invoices.Add(inv);
+        _context.SaveChanges();
 
         await _repository.DeleteAsync(inv);
 
@@ -346,7 +368,7 @@ public class InvoiceRepositoryTests
     /// </summary>
     private Invoice BuildInvoiceWithOrderId(Guid orderId)
     {
-        var inv = new Invoice(Guid.NewGuid(), Guid.NewGuid(), "USD");
+        var inv = new Invoice(Guid.NewGuid(), $"INV-ORDERID-{Guid.NewGuid().ToString()[..8]}", Guid.NewGuid(), "USD");
         inv.AddLine("Item", 1, 100m, 10m);
         _context.Invoices.Add(inv);
         _context.Entry(inv).Property(e => e.OrderId).CurrentValue = orderId;

--- a/src/MyApp.Billing/test/MyApp.Billing.Infrastructure.Tests/Repositories/PaymentRepositoryTests.cs
+++ b/src/MyApp.Billing/test/MyApp.Billing.Infrastructure.Tests/Repositories/PaymentRepositoryTests.cs
@@ -23,7 +23,7 @@ public class PaymentRepositoryTests
     /// <summary>Seeds a persisted invoice so payments can reference a valid FK.</summary>
     private Invoice SeedInvoice()
     {
-        var inv = new Invoice(Guid.NewGuid(), Guid.NewGuid(), "USD");
+        var inv = new Invoice(Guid.NewGuid(), $"INV-PAY-{Guid.NewGuid().ToString()[..8]}", Guid.NewGuid(), "USD");
         inv.AddLine("Widget", 1, 100m, 10m);
         inv.Issue($"INV-{Guid.NewGuid().ToString()[..8]}", DateTime.UtcNow, 30);
         _context.Invoices.Add(inv);
@@ -97,7 +97,7 @@ public class PaymentRepositoryTests
     {
         var inv = SeedInvoice();
         var earlier = DateTime.UtcNow.AddDays(-2);
-        var later   = DateTime.UtcNow.AddDays(-1);
+        var later = DateTime.UtcNow.AddDays(-1);
 
         AddPayment(inv.Id, 20m, paidAt: earlier);
         await Task.Delay(5);

--- a/src/MyApp.Shared.Tests/Infrastructure/Messaging/ServiceInvokerTests.cs
+++ b/src/MyApp.Shared.Tests/Infrastructure/Messaging/ServiceInvokerTests.cs
@@ -497,11 +497,11 @@ public class ServiceInvokerTests
         var expectedResponse = new TestResponse { Result = "Success" };
 
         _mockDaprClient
-            #pragma warning disable CS0618 // Dapr InvokeMethodAsync(HttpRequestMessage) is obsolete but tested intentionally
+#pragma warning disable CS0618 // Dapr InvokeMethodAsync(HttpRequestMessage) is obsolete but tested intentionally
             .Setup(c => c.InvokeMethodAsync<TestResponse>(
                 request,
                 It.IsAny<CancellationToken>()))
-            #pragma warning restore CS0618
+#pragma warning restore CS0618
             .ReturnsAsync(expectedResponse);
 
         // Act
@@ -528,11 +528,11 @@ public class ServiceInvokerTests
         var exception = new Exception("Dapr error");
 
         _mockDaprClient
-            #pragma warning disable CS0618 // Dapr InvokeMethodAsync(HttpRequestMessage) is obsolete but tested intentionally
+#pragma warning disable CS0618 // Dapr InvokeMethodAsync(HttpRequestMessage) is obsolete but tested intentionally
             .Setup(c => c.InvokeMethodAsync<TestResponse>(
                 request,
                 It.IsAny<CancellationToken>()))
-            #pragma warning restore CS0618
+#pragma warning restore CS0618
             .ThrowsAsync(exception);
 
         // Act & Assert
@@ -578,11 +578,11 @@ public class ServiceInvokerTests
         var expectedResponse = new TestResponse { Result = "Success" };
 
         _mockDaprClient
-            #pragma warning disable CS0618 // Dapr InvokeMethodAsync(HttpRequestMessage) is obsolete but tested intentionally
+#pragma warning disable CS0618 // Dapr InvokeMethodAsync(HttpRequestMessage) is obsolete but tested intentionally
             .Setup(c => c.InvokeMethodAsync<TestResponse>(
                 request,
                 It.IsAny<CancellationToken>()))
-            #pragma warning restore CS0618
+#pragma warning restore CS0618
             .ReturnsAsync(expectedResponse);
 
         // Act

--- a/src/MyApp.Shared/MyApp.Shared.Infrastructure/Messaging/ServiceInvoker.cs
+++ b/src/MyApp.Shared/MyApp.Shared.Infrastructure/Messaging/ServiceInvoker.cs
@@ -64,14 +64,14 @@ public class ServiceInvoker : IServiceInvoker
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            #pragma warning disable CS0618 // Dapr InvokeMethodAsync is obsolete but intentionally used
+#pragma warning disable CS0618 // Dapr InvokeMethodAsync is obsolete but intentionally used
             var response = await _daprClient.InvokeMethodAsync<TRequest, TResponse>(
                 httpMethod,
                 serviceName,
                 methodPath,
                 request,
                 cancellationToken);
-            #pragma warning restore CS0618
+#pragma warning restore CS0618
 
             if (_enableLogging)
             {
@@ -117,13 +117,13 @@ public class ServiceInvoker : IServiceInvoker
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            #pragma warning disable CS0618 // Dapr InvokeMethodAsync is obsolete but intentionally used
+#pragma warning disable CS0618 // Dapr InvokeMethodAsync is obsolete but intentionally used
             var response = await _daprClient.InvokeMethodAsync<TResponse>(
                 httpMethod,
                 serviceName,
                 methodPath,
                 cancellationToken);
-            #pragma warning restore CS0618
+#pragma warning restore CS0618
 
             if (_enableLogging)
             {
@@ -169,13 +169,13 @@ public class ServiceInvoker : IServiceInvoker
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            #pragma warning disable CS0618 // Dapr InvokeMethodAsync is obsolete but intentionally used
+#pragma warning disable CS0618 // Dapr InvokeMethodAsync is obsolete but intentionally used
             await _daprClient.InvokeMethodAsync(
                 httpMethod,
                 serviceName,
                 methodPath,
                 cancellationToken);
-            #pragma warning restore CS0618
+#pragma warning restore CS0618
 
             if (_enableLogging)
             {
@@ -260,13 +260,13 @@ public class ServiceInvoker : IServiceInvoker
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            #pragma warning disable CS0618 // Dapr InvokeMethodAsync is obsolete but intentionally used
+#pragma warning disable CS0618 // Dapr InvokeMethodAsync is obsolete but intentionally used
             var response = await _daprClient.InvokeMethodAsync<TResponse>(request, cancellationToken);
 
             if (_enableLogging)
             {
                 _logger.LogTrace("Successfully invoked service with custom request");
-            #pragma warning restore CS0618
+#pragma warning restore CS0618
             }
 
             return response;


### PR DESCRIPTION
Add invoice search and stricter invoice-number handling across the billing service, plus Dapr sidecar mapping improvements.

Key changes:
- API: Add GET /api/billing/invoices/search endpoint with query binding and validation; update routes for invoices, payments and credit-notes.
- Domain/DTOs: CreateInvoiceDto now requires InvoiceNumber; Invoice entity and Issue flow validate non-empty invoice numbers.
- Service/Contracts: IInvoiceService gained GetInvoiceByInvoiceNumberAsync and QueryInvoicesAsync; InvoiceService enforces uniqueness on create/issue and exposes invoice-number lookup and query mapping.
- Repository: IInvoiceRepository.SaveChangesAsync added; InvoiceRepository overrides GetByIdAsync and QueryAsync (includes lines, applies spec, returns PaginatedResult) and implements SaveChangesAsync to correct EF tracking before save.
- Specs: Add InvoiceQuerySpec to support filtering, search, ranges and pagination.
- AppHost: Refactor Dapr sidecar mapping and pass pubSub/stateStore references when adding web projects.
- Tests: Update and extend unit/integration tests to cover new behaviors (search, invoice-number uniqueness, repo save/query changes).

These changes enable flexible invoice querying, ensure invoice-number uniqueness at write boundaries, and wire Dapr components into project sidecars.