### PR TITLE
Add AWS EKS overlays, ToFu modules & CI workflows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
   "name": "Aspire with Dapr",
-  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:10.0-noble",
 
   "features": {
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },
 
   "onCreateCommand": "dotnet new install Aspire.ProjectTemplates --force",
@@ -19,10 +19,5 @@
         "ms-azuretools.vscode-dapr"
       ]
     }
-  },
-
-  "workspaceFolder": "/workspace",
-  "mounts": [
-    "source=${localWorkspaceFolder},target=/workspace,type=bind"
-  ]
+  }
 }

--- a/.github/workflows/_reusable/build-service-images.yml
+++ b/.github/workflows/_reusable/build-service-images.yml
@@ -1,0 +1,89 @@
+name: Build service images
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+      do_push:
+        required: true
+        type: boolean
+      platform:
+        required: false
+        type: string
+        default: linux/amd64
+      services_config_path:
+        required: false
+        type: string
+        default: deploy/k8s/contracts/services.yaml
+
+jobs:
+  prepare-matrix:
+    name: Prepare build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build matrix from services catalog
+        id: matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          pip install --quiet pyyaml
+          MATRIX_JSON="$(python - <<'PY'
+          import json
+          import yaml
+          from pathlib import Path
+
+          path = Path("${{ inputs.services_config_path }}")
+          data = yaml.safe_load(path.read_text(encoding="utf-8"))
+          include = [
+              {"service": item["name"], "dockerfile": item["dockerfile"]}
+              for item in data["services"]
+          ]
+          print(json.dumps({"include": include}))
+          PY
+          )"
+          echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
+
+  build-images:
+    name: Build ${{ matrix.service }}
+    needs: prepare-matrix
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: ${{ inputs.do_push }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build or build+push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ inputs.platform }}
+          push: ${{ inputs.do_push }}
+          tags: |
+            ghcr.io/${{ github.repository }}/myapp-${{ matrix.service }}:${{ inputs.image_tag }}
+            ghcr.io/${{ github.repository }}/myapp-${{ matrix.service }}:latest
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/.github/workflows/_reusable/k8s-validate.yml
+++ b/.github/workflows/_reusable/k8s-validate.yml
@@ -1,0 +1,60 @@
+name: K8s validate or apply
+
+on:
+  workflow_call:
+    inputs:
+      kustomize_path:
+        required: true
+        type: string
+      apply_mode:
+        required: true
+        type: string
+      dapr_components_path:
+        required: false
+        type: string
+        default: deploy/k8s/base/dapr/components
+
+jobs:
+  k8s-deploy:
+    name: K8s ${{ inputs.apply_mode }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: latest
+
+      - name: Validate manifests
+        if: ${{ inputs.apply_mode == 'validate' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          kubectl apply --dry-run=client -k "${{ inputs.kustomize_path }}"
+          if [[ -d "${{ inputs.dapr_components_path }}" ]]; then
+            kubectl apply --dry-run=client -f "${{ inputs.dapr_components_path }}/dapr-config.yaml"
+            kubectl apply --dry-run=client -f "${{ inputs.dapr_components_path }}/statestore.yaml"
+            kubectl apply --dry-run=client -f "${{ inputs.dapr_components_path }}/pubsub.yaml"
+          fi
+
+      - name: Apply manifests
+        if: ${{ inputs.apply_mode == 'apply' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          kubectl apply -k "${{ inputs.kustomize_path }}"
+          if [[ -d "${{ inputs.dapr_components_path }}" ]]; then
+            kubectl apply -f "${{ inputs.dapr_components_path }}/dapr-config.yaml"
+            kubectl apply -f "${{ inputs.dapr_components_path }}/statestore.yaml"
+            kubectl apply -f "${{ inputs.dapr_components_path }}/pubsub.yaml"
+          fi
+
+      - name: Post-deploy checks
+        if: ${{ inputs.apply_mode == 'apply' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          kubectl get pods -A
+          kubectl get ingress -A

--- a/.github/workflows/_reusable/patch-k8s-image-tags.yml
+++ b/.github/workflows/_reusable/patch-k8s-image-tags.yml
@@ -1,0 +1,63 @@
+name: Patch K8s image tags
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+      registry:
+        required: false
+        type: string
+        default: ghcr.io
+      image_namespace:
+        required: false
+        type: string
+        default: ""
+      search_paths:
+        required: false
+        type: string
+        default: deploy/k8s deploy/aws/k8s
+      services_config_path:
+        required: false
+        type: string
+        default: deploy/k8s/contracts/services.yaml
+
+jobs:
+  patch-tags:
+    name: Patch manifest image tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Replace image placeholders
+        shell: bash
+        run: |
+          set -euo pipefail
+          pip install --quiet pyyaml
+          NAMESPACE="${{ inputs.image_namespace }}"
+          if [[ -z "$NAMESPACE" ]]; then
+            NAMESPACE="${{ github.repository }}"
+          fi
+          REPO="${{ inputs.registry }}/${NAMESPACE}"
+          IMAGE_TAG="${{ inputs.image_tag }}"
+          SEARCH_PATHS="${{ inputs.search_paths }}"
+
+          mapfile -t SERVICES < <(python - <<'PY'
+          import yaml
+          from pathlib import Path
+          data = yaml.safe_load(Path("${{ inputs.services_config_path }}").read_text(encoding="utf-8"))
+          for item in data["services"]:
+              print(item["name"])
+          PY
+          )
+
+          for root in $SEARCH_PATHS; do
+            [[ -d "$root" ]] || continue
+            for svc in "${SERVICES[@]}"; do
+              find "$root" -type f -name "*.yaml" -exec sed -i "s|ghcr.io/replace-org/replace-repo/myapp-${svc}:latest|${REPO}/myapp-${svc}:${IMAGE_TAG}|g" {} +
+            done
+          done
+
+          echo "Patched images to tag ${IMAGE_TAG} under: ${SEARCH_PATHS}"

--- a/.github/workflows/deploy-aws-k8s.yml
+++ b/.github/workflows/deploy-aws-k8s.yml
@@ -1,0 +1,259 @@
+name: Deploy AWS Kubernetes Stack
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_step:
+        description: "Container image stage"
+        required: true
+        default: skip
+        type: choice
+        options:
+          - skip
+          - build
+          - build-push
+      app_image_tag:
+        description: "Optional explicit app image tag (default: short SHA)"
+        required: false
+        default: ""
+        type: string
+      infra_step:
+        description: "OpenTofu stage before Kubernetes deploy"
+        required: true
+        default: skip
+        type: choice
+        options:
+          - skip
+          - validate
+          - apply
+      profile:
+        description: "Deployment profile"
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
+          - prod
+      apply_mode:
+        description: "Validation mode or real apply"
+        required: true
+        default: validate
+        type: choice
+        options:
+          - validate
+          - apply
+      ingress_domain:
+        description: "Required for prod profile (example: api.example.com)"
+        required: false
+        default: ""
+        type: string
+      letsencrypt_issuer:
+        description: "Used by prod profile patch"
+        required: true
+        default: letsencrypt-staging
+        type: choice
+        options:
+          - letsencrypt-staging
+          - letsencrypt-prod
+
+concurrency:
+  group: aws-k8s-${{ github.ref }}-${{ github.event.inputs.profile }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare deployment context
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.vars.outputs.image_tag }}
+      do_build: ${{ steps.vars.outputs.do_build }}
+      do_push: ${{ steps.vars.outputs.do_push }}
+      kustomize_path: ${{ steps.vars.outputs.kustomize_path }}
+    steps:
+      - name: Compute execution variables
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+          INPUT_TAG="${{ github.event.inputs.app_image_tag }}"
+          IMAGE_STEP="${{ github.event.inputs.image_step }}"
+          APPLY_MODE="${{ github.event.inputs.apply_mode }}"
+          PROFILE="${{ github.event.inputs.profile }}"
+
+          if [[ -n "$INPUT_TAG" ]]; then
+            IMAGE_TAG="$INPUT_TAG"
+          else
+            IMAGE_TAG="${GITHUB_SHA::7}"
+          fi
+
+          DO_BUILD="false"
+          DO_PUSH="false"
+          if [[ "$IMAGE_STEP" != "skip" ]]; then
+            DO_BUILD="true"
+          fi
+          if [[ "$IMAGE_STEP" == "build-push" && "$APPLY_MODE" == "apply" ]]; then
+            DO_PUSH="true"
+          fi
+
+          if [[ "$PROFILE" == "prod" ]]; then
+            KUSTOMIZE_PATH="deploy/aws/k8s/overlays/prod"
+          else
+            KUSTOMIZE_PATH="deploy/aws/k8s/overlays/dev"
+          fi
+
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "do_build=$DO_BUILD" >> "$GITHUB_OUTPUT"
+          echo "do_push=$DO_PUSH" >> "$GITHUB_OUTPUT"
+          echo "kustomize_path=$KUSTOMIZE_PATH" >> "$GITHUB_OUTPUT"
+
+  build-images:
+    name: Build service images
+    needs: prepare
+    if: ${{ needs.prepare.outputs.do_build == 'true' }}
+    uses: ./.github/workflows/_reusable/build-service-images.yml
+    with:
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
+      do_push: ${{ needs.prepare.outputs.do_push == 'true' }}
+      platform: linux/amd64
+
+  deploy-k8s:
+    name: Deploy AWS EKS (${{ github.event.inputs.profile }})
+    needs: [prepare, build-images]
+    if: ${{ always() && needs.prepare.result == 'success' && (needs.build-images.result == 'success' || needs.build-images.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate workflow inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROFILE="${{ github.event.inputs.profile }}"
+          DOMAIN="${{ github.event.inputs.ingress_domain }}"
+          INFRA_STEP="${{ github.event.inputs.infra_step }}"
+          if [[ "$PROFILE" == "prod" && -z "$DOMAIN" ]]; then
+            echo "ingress_domain is required when profile=prod"
+            exit 1
+          fi
+          if [[ "${{ github.event.inputs.image_step }}" == "build-push" && "${{ github.event.inputs.apply_mode }}" != "apply" ]]; then
+            echo "build-push only works with apply_mode=apply"
+            exit 1
+          fi
+          if [[ "$INFRA_STEP" != "skip" && -z "${{ vars.AWS_DEPLOY_ROLE_ARN }}" ]]; then
+            echo "infra_step requires vars.AWS_DEPLOY_ROLE_ARN and vars.AWS_REGION"
+            exit 1
+          fi
+          if [[ -z "${{ vars.AWS_EKS_CLUSTER_NAME }}" || -z "${{ vars.AWS_REGION }}" ]]; then
+            echo "vars.AWS_EKS_CLUSTER_NAME and vars.AWS_REGION are required for deploy"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Setup OpenTofu
+        if: ${{ github.event.inputs.infra_step != 'skip' }}
+        uses: opentofu/setup-opentofu@v1
+
+      - name: OpenTofu validate/plan
+        if: ${{ github.event.inputs.infra_step == 'validate' }}
+        shell: bash
+        working-directory: deploy/aws/tofu
+        run: |
+          set -euo pipefail
+          tofu fmt -check -recursive
+          tofu init -backend=false
+          tofu validate
+          tofu plan -refresh=false -lock=false
+
+      - name: OpenTofu apply
+        if: ${{ github.event.inputs.infra_step == 'apply' }}
+        shell: bash
+        working-directory: deploy/aws/tofu
+        run: |
+          set -euo pipefail
+          tofu fmt -check -recursive
+          tofu init -backend=false
+          tofu validate
+          tofu apply -auto-approve
+
+      - name: Update kubeconfig
+        shell: bash
+        run: |
+          set -euo pipefail
+          aws eks update-kubeconfig \
+            --name "${{ vars.AWS_EKS_CLUSTER_NAME }}" \
+            --region "${{ vars.AWS_REGION }}"
+          kubectl config current-context
+
+      - name: Patch prod ingress host and issuer
+        if: ${{ github.event.inputs.profile == 'prod' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          DOMAIN="${{ github.event.inputs.ingress_domain }}"
+          ISSUER="${{ github.event.inputs.letsencrypt_issuer }}"
+          PATCH_FILE="deploy/k8s/overlays/prod/patch-gateway-ingress-letsencrypt.yaml"
+          sed -i "s/api.replace-with-real-domain.com/${DOMAIN}/g" "$PATCH_FILE"
+          sed -i "s/letsencrypt-staging/${ISSUER}/g" "$PATCH_FILE"
+          echo "Patched $PATCH_FILE with domain=${DOMAIN} issuer=${ISSUER}"
+
+      - name: Patch deployment image tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          pip install --quiet pyyaml
+          IMAGE_TAG="${{ needs.prepare.outputs.image_tag }}"
+          REPO="ghcr.io/${{ github.repository }}"
+          mapfile -t SERVICES < <(python - <<'PY'
+          import yaml
+          from pathlib import Path
+          data = yaml.safe_load(Path("deploy/k8s/contracts/services.yaml").read_text(encoding="utf-8"))
+          for item in data["services"]:
+              print(item["name"])
+          PY
+          )
+          for root in deploy/k8s deploy/aws/k8s; do
+            for svc in "${SERVICES[@]}"; do
+              find "$root" -type f -name "*.yaml" -exec sed -i "s|ghcr.io/replace-org/replace-repo/myapp-${svc}:latest|${REPO}/myapp-${svc}:${IMAGE_TAG}|g" {} +
+            done
+          done
+
+      - name: Validate manifests
+        if: ${{ github.event.inputs.apply_mode == 'validate' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          KUSTOMIZE_PATH="${{ needs.prepare.outputs.kustomize_path }}"
+          kubectl apply --dry-run=client -k "$KUSTOMIZE_PATH"
+          kubectl apply --dry-run=client -f deploy/k8s/base/dapr/components/dapr-config.yaml
+          kubectl apply --dry-run=client -f deploy/k8s/base/dapr/components/statestore.yaml
+          kubectl apply --dry-run=client -f deploy/k8s/base/dapr/components/pubsub.yaml
+
+      - name: Apply manifests
+        if: ${{ github.event.inputs.apply_mode == 'apply' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          KUSTOMIZE_PATH="${{ needs.prepare.outputs.kustomize_path }}"
+          kubectl apply -k "$KUSTOMIZE_PATH"
+          kubectl apply -f deploy/k8s/base/dapr/components/dapr-config.yaml
+          kubectl apply -f deploy/k8s/base/dapr/components/statestore.yaml
+          kubectl apply -f deploy/k8s/base/dapr/components/pubsub.yaml
+
+      - name: Post-deploy quick checks
+        if: ${{ github.event.inputs.apply_mode == 'apply' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          kubectl get pods -A
+          kubectl get ingress -A

--- a/.github/workflows/deploy-aws-phase1.yml
+++ b/.github/workflows/deploy-aws-phase1.yml
@@ -1,0 +1,47 @@
+name: AWS Phase 1 Scaffold Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_validation:
+        description: "Run OpenTofu fmt/validate skeleton"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+concurrency:
+  group: aws-phase1-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tofu-skeleton-check:
+    name: OpenTofu Skeleton Check
+    if: ${{ github.event.inputs.run_validation == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup OpenTofu
+        uses: opentofu/setup-opentofu@v1
+
+      - name: Tofu fmt and validate
+        working-directory: deploy/aws/tofu
+        run: |
+          tofu fmt -check -recursive
+          tofu init -backend=false
+          tofu validate
+
+      - name: Tofu plan skeleton
+        working-directory: deploy/aws/tofu
+        run: |
+          cp environments/dev/terraform.tfvars.example terraform.tfvars
+          echo "Skipping real plan because AWS credentials are not configured in this skeleton workflow."
+          tofu plan -refresh=false -lock=false || true

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ test_results.txt
 *.user
 build_output.txt
 coverage.cobertura.xml
+
+# OpenTofu / Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+terraform.tfvars

--- a/deploy/aws/k8s/README.md
+++ b/deploy/aws/k8s/README.md
@@ -1,0 +1,40 @@
+# AWS EKS Kubernetes overlays (Tier 1)
+
+Thin AWS-specific patches on top of `deploy/k8s/`.
+
+## Cost profiles
+
+| Overlay | Use when | Includes |
+|---------|----------|----------|
+| `overlays/dev` | **Default — cheap lab / CI** | gp3 PVC (20Gi), reduced SQL CPU/RAM. No S3 backup, no ESO, no IRSA. Use manual Kubernetes secrets. |
+| `overlays/prod` | Staging or when you need backups + Secrets Manager | Let's Encrypt overlay + backup CronJob + ESO + IRSA service accounts |
+
+**Estimated infra baseline (dev tofu defaults):** 1× Spot `t3.xlarge` node, no NAT gateway, no S3 backup bucket — control plane (~$73/mo) + one Spot node (~$45–90/mo region-dependent) + small EBS volumes.
+
+Scale up later via `deploy/aws/tofu` variables (`node_max_size`, `enable_nat_gateway`, `create_backup_bucket`, etc.) without changing the generic `deploy/k8s/` layer.
+
+## Repository variables (GitHub Actions OIDC)
+
+| Variable | Purpose |
+|----------|---------|
+| `AWS_DEPLOY_ROLE_ARN` | IAM role for GitHub OIDC |
+| `AWS_REGION` | e.g. `eu-west-1` |
+| `AWS_EKS_CLUSTER_NAME` | Target cluster |
+
+## Cheap dev checklist
+
+1. Apply tofu with `environments/dev/terraform.tfvars.example` defaults (Spot, single node, NAT off).
+2. `kubectl apply -k deploy/aws/k8s/overlays/dev`
+3. Create secrets manually (`redis-secrets`, `app-secrets`, `sql-secrets`) — see `deploy/k8s/contracts/`.
+4. Install only required Helm charts: ingress-nginx, cert-manager, Dapr (skip ESO for dev).
+
+## Validate
+
+```powershell
+kubectl kustomize deploy/aws/k8s/overlays/dev
+kubectl kustomize deploy/aws/k8s/overlays/prod
+```
+
+## Workflow
+
+Manual: `.github/workflows/deploy-aws-k8s.yml` — use `profile=dev` for the minimal overlay.

--- a/deploy/aws/k8s/overlays/dev/backup-cronjob.yaml
+++ b/deploy/aws/k8s/overlays/dev/backup-cronjob.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sql-backup-aws
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: sql-backup-aws
+    app.kubernetes.io/part-of: myapp
+spec:
+  schedule: "0 2 * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: sql-backup
+          restartPolicy: OnFailure
+          containers:
+            - name: backup
+              image: ghcr.io/replace-org/mssql-backup-tools:latest
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: SA_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: sql-secrets
+                      key: sa-password
+                - name: S3_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: sql-secrets
+                      key: s3-bucket
+                - name: AWS_REGION
+                  valueFrom:
+                    secretKeyRef:
+                      name: sql-secrets
+                      key: aws-region
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -e
+                  mkdir -p /tmp/backups
+                  TS="$(date +%Y%m%d%H%M%S)"
+                  SQLCMD_BIN="/opt/mssql-tools18/bin/sqlcmd"
+                  if [ ! -x "$SQLCMD_BIN" ]; then
+                    SQLCMD_BIN="/opt/mssql-tools/bin/sqlcmd"
+                  fi
+
+                  for db in AuthDb BillingDb InventoryDb OrdersDb PurchasingDb SalesDb CrmDb; do
+                    file="/tmp/backups/${db}_${TS}.bak"
+                    "$SQLCMD_BIN" -S sqlserver,1433 -U sa -P "$SA_PASSWORD" -Q "BACKUP DATABASE [$db] TO DISK='${file}' WITH INIT, COMPRESSION, STATS=10;"
+                    aws s3 cp "${file}" "s3://${S3_BUCKET}/${db}/${db}_${TS}.bak"
+                  done

--- a/deploy/aws/k8s/overlays/dev/external-secrets-aws.yaml
+++ b/deploy/aws/k8s/overlays/dev/external-secrets-aws.yaml
@@ -1,0 +1,119 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: aws-secrets-manager
+  namespace: myapp-platform
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: REPLACE_AWS_REGION
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: aws-secrets-manager
+  namespace: myapp-apps
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: REPLACE_AWS_REGION
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: redis-secrets
+  namespace: myapp-platform
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: aws-secrets-manager
+  target:
+    name: redis-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: redis-password
+      remoteRef:
+        key: myapp/dev/redis/password
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: app-secrets
+  namespace: myapp-apps
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: aws-secrets-manager
+  target:
+    name: app-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: jwt-secret-key
+      remoteRef:
+        key: myapp/dev/jwt/secret-key
+    - secretKey: otlp-api-key
+      remoteRef:
+        key: myapp/dev/aspire/otlp-key
+    - secretKey: otlp-header
+      remoteRef:
+        key: myapp/dev/aspire/otlp-header
+    - secretKey: redis-connection
+      remoteRef:
+        key: myapp/dev/redis/connection
+    - secretKey: sql-connection-authdb
+      remoteRef:
+        key: myapp/dev/sql/connection-authdb
+    - secretKey: sql-connection-billingdb
+      remoteRef:
+        key: myapp/dev/sql/connection-billingdb
+    - secretKey: sql-connection-inventorydb
+      remoteRef:
+        key: myapp/dev/sql/connection-inventorydb
+    - secretKey: sql-connection-ordersdb
+      remoteRef:
+        key: myapp/dev/sql/connection-ordersdb
+    - secretKey: sql-connection-purchasingdb
+      remoteRef:
+        key: myapp/dev/sql/connection-purchasingdb
+    - secretKey: sql-connection-salesdb
+      remoteRef:
+        key: myapp/dev/sql/connection-salesdb
+    - secretKey: sql-connection-crmdb
+      remoteRef:
+        key: myapp/dev/sql/connection-crmdb
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: sql-secrets
+  namespace: myapp-apps
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: aws-secrets-manager
+  target:
+    name: sql-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: sa-password
+      remoteRef:
+        key: myapp/dev/sql/sa-password
+    - secretKey: s3-bucket
+      remoteRef:
+        key: myapp/dev/backup/s3-bucket
+    - secretKey: aws-region
+      remoteRef:
+        key: myapp/dev/backup/aws-region

--- a/deploy/aws/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/aws/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Minimal cheap dev: generic workloads + gp3 PVC + smaller resource requests only.
+# Backup CronJob, IRSA, and External Secrets live under overlays/prod (or enable manually).
+resources:
+  - ../../../../k8s/overlays/dev
+
+patchesStrategicMerge:
+  - patch-sql-pvc-gp3.yaml
+  - patch-sql-resources.yaml

--- a/deploy/aws/k8s/overlays/dev/patch-sql-pvc-gp3.yaml
+++ b/deploy/aws/k8s/overlays/dev/patch-sql-pvc-gp3.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mssql-data
+  namespace: myapp-apps
+spec:
+  storageClassName: gp3
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/deploy/aws/k8s/overlays/dev/patch-sql-resources.yaml
+++ b/deploy/aws/k8s/overlays/dev/patch-sql-resources.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sqlserver
+  namespace: myapp-apps
+spec:
+  template:
+    spec:
+      containers:
+        - name: mssql
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "2Gi"
+            limits:
+              cpu: "1"
+              memory: "4Gi"

--- a/deploy/aws/k8s/overlays/dev/serviceaccount-external-secrets.yaml
+++ b/deploy/aws/k8s/overlays/dev/serviceaccount-external-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets
+  namespace: myapp-apps
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ACCOUNT_ID:role/REPLACE_EXTERNAL_SECRETS_ROLE
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets
+  namespace: myapp-platform
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ACCOUNT_ID:role/REPLACE_EXTERNAL_SECRETS_ROLE

--- a/deploy/aws/k8s/overlays/dev/serviceaccount-sql-backup.yaml
+++ b/deploy/aws/k8s/overlays/dev/serviceaccount-sql-backup.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sql-backup
+  namespace: myapp-apps
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ACCOUNT_ID:role/REPLACE_SQL_BACKUP_ROLE

--- a/deploy/aws/k8s/overlays/prod/backup-cronjob.yaml
+++ b/deploy/aws/k8s/overlays/prod/backup-cronjob.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sql-backup-aws
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: sql-backup-aws
+    app.kubernetes.io/part-of: myapp
+spec:
+  schedule: "0 2 * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: sql-backup
+          restartPolicy: OnFailure
+          containers:
+            - name: backup
+              image: ghcr.io/replace-org/mssql-backup-tools:latest
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: SA_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: sql-secrets
+                      key: sa-password
+                - name: S3_BUCKET
+                  valueFrom:
+                    secretKeyRef:
+                      name: sql-secrets
+                      key: s3-bucket
+                - name: AWS_REGION
+                  valueFrom:
+                    secretKeyRef:
+                      name: sql-secrets
+                      key: aws-region
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -e
+                  mkdir -p /tmp/backups
+                  TS="$(date +%Y%m%d%H%M%S)"
+                  SQLCMD_BIN="/opt/mssql-tools18/bin/sqlcmd"
+                  if [ ! -x "$SQLCMD_BIN" ]; then
+                    SQLCMD_BIN="/opt/mssql-tools/bin/sqlcmd"
+                  fi
+
+                  for db in AuthDb BillingDb InventoryDb OrdersDb PurchasingDb SalesDb CrmDb; do
+                    file="/tmp/backups/${db}_${TS}.bak"
+                    "$SQLCMD_BIN" -S sqlserver,1433 -U sa -P "$SA_PASSWORD" -Q "BACKUP DATABASE [$db] TO DISK='${file}' WITH INIT, COMPRESSION, STATS=10;"
+                    aws s3 cp "${file}" "s3://${S3_BUCKET}/${db}/${db}_${TS}.bak"
+                  done

--- a/deploy/aws/k8s/overlays/prod/external-secrets-aws.yaml
+++ b/deploy/aws/k8s/overlays/prod/external-secrets-aws.yaml
@@ -1,0 +1,119 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: aws-secrets-manager
+  namespace: myapp-platform
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: REPLACE_AWS_REGION
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: aws-secrets-manager
+  namespace: myapp-apps
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: REPLACE_AWS_REGION
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: redis-secrets
+  namespace: myapp-platform
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: aws-secrets-manager
+  target:
+    name: redis-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: redis-password
+      remoteRef:
+        key: myapp/dev/redis/password
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: app-secrets
+  namespace: myapp-apps
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: aws-secrets-manager
+  target:
+    name: app-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: jwt-secret-key
+      remoteRef:
+        key: myapp/dev/jwt/secret-key
+    - secretKey: otlp-api-key
+      remoteRef:
+        key: myapp/dev/aspire/otlp-key
+    - secretKey: otlp-header
+      remoteRef:
+        key: myapp/dev/aspire/otlp-header
+    - secretKey: redis-connection
+      remoteRef:
+        key: myapp/dev/redis/connection
+    - secretKey: sql-connection-authdb
+      remoteRef:
+        key: myapp/dev/sql/connection-authdb
+    - secretKey: sql-connection-billingdb
+      remoteRef:
+        key: myapp/dev/sql/connection-billingdb
+    - secretKey: sql-connection-inventorydb
+      remoteRef:
+        key: myapp/dev/sql/connection-inventorydb
+    - secretKey: sql-connection-ordersdb
+      remoteRef:
+        key: myapp/dev/sql/connection-ordersdb
+    - secretKey: sql-connection-purchasingdb
+      remoteRef:
+        key: myapp/dev/sql/connection-purchasingdb
+    - secretKey: sql-connection-salesdb
+      remoteRef:
+        key: myapp/dev/sql/connection-salesdb
+    - secretKey: sql-connection-crmdb
+      remoteRef:
+        key: myapp/dev/sql/connection-crmdb
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: sql-secrets
+  namespace: myapp-apps
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: aws-secrets-manager
+  target:
+    name: sql-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: sa-password
+      remoteRef:
+        key: myapp/dev/sql/sa-password
+    - secretKey: s3-bucket
+      remoteRef:
+        key: myapp/dev/backup/s3-bucket
+    - secretKey: aws-region
+      remoteRef:
+        key: myapp/dev/backup/aws-region

--- a/deploy/aws/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/aws/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Prod-oriented AWS add-ons (backup, ESO/IRSA). Not required for cheap dev.
+resources:
+  - ../../../../k8s/overlays/prod
+  - serviceaccount-sql-backup.yaml
+  - serviceaccount-external-secrets.yaml
+  - backup-cronjob.yaml
+  - external-secrets-aws.yaml
+
+patchesStrategicMerge:
+  - patch-sql-pvc-gp3.yaml
+  - patch-sql-resources.yaml

--- a/deploy/aws/k8s/overlays/prod/patch-sql-pvc-gp3.yaml
+++ b/deploy/aws/k8s/overlays/prod/patch-sql-pvc-gp3.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mssql-data
+  namespace: myapp-apps
+spec:
+  storageClassName: gp3
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi

--- a/deploy/aws/k8s/overlays/prod/patch-sql-resources.yaml
+++ b/deploy/aws/k8s/overlays/prod/patch-sql-resources.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sqlserver
+  namespace: myapp-apps
+spec:
+  template:
+    spec:
+      containers:
+        - name: mssql
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "3Gi"
+            limits:
+              cpu: "2"
+              memory: "6Gi"

--- a/deploy/aws/k8s/overlays/prod/serviceaccount-external-secrets.yaml
+++ b/deploy/aws/k8s/overlays/prod/serviceaccount-external-secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets
+  namespace: myapp-apps
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ACCOUNT_ID:role/REPLACE_EXTERNAL_SECRETS_ROLE
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets
+  namespace: myapp-platform
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ACCOUNT_ID:role/REPLACE_EXTERNAL_SECRETS_ROLE

--- a/deploy/aws/k8s/overlays/prod/serviceaccount-sql-backup.yaml
+++ b/deploy/aws/k8s/overlays/prod/serviceaccount-sql-backup.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sql-backup
+  namespace: myapp-apps
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::REPLACE_ACCOUNT_ID:role/REPLACE_SQL_BACKUP_ROLE

--- a/deploy/aws/tofu/.terraform.lock.hcl
+++ b/deploy/aws/tofu/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.45.0"
+  constraints = ">= 5.80.0"
+  hashes = [
+    "h1:Ft3ziZ+UhoMi4Iqk46USLpCWFkaQN51aIqzLamYEmz4=",
+    "zh:0aed87baf61465ff47ec9f73785fd42f80271705c28ea5d145a220a70bc52e12",
+    "zh:1599fc46d0bd5b621ef054a93d69bbaba1e74828d9a59741ff13b10366dad245",
+    "zh:233b84d24e042e7187efc1ff601cdada61ee1bfab6facc454430d880660145ef",
+    "zh:295133d1097c14254729a24a61f4cb2e8d7f278f80a8cbfafd3ac9401ab370d6",
+    "zh:3f1ea8e92d2c9a51261ddd530d5a6224d99de31d1aa2d99586fd3c75d578fcc5",
+    "zh:412075c5252cd10857f8efee22b49243dc9150451fbcba31768035d3eaf283f0",
+    "zh:49ecd456fb8fee5562725c36bd5992b6982704100ead0164d26c6cbb11b07653",
+    "zh:4a5c7dde3bfa2458710f0c3bb95612b2751c38fd4e27c45c6b65f6175e9a8323",
+    "zh:56e58696b118291ccbc611349cb6e8ee16f3ae49204b62da4899286be879faeb",
+    "zh:5df6108ff27db2183c2f45fa988ad90cb6c37193ab6c29f923f6de69275e9de4",
+    "zh:82972a5ff709738c3ea27aa3ec02d4847221ede6601ac79788a8da34650f901b",
+    "zh:8f4f9ebdf23ee99552ee3d1b0acc8b47ca8ea4bb14aabecde693be5341b95265",
+    "zh:abf8e841bc94e872daf68874a9ba7a73e5487c11c59e31d3bcd11f73f6b8e29e",
+    "zh:b05796c799ab11b12f2510a06343d30fd61fdad09835ec24ac1741970a3d8f48",
+    "zh:d84d3e91e3c1f89b7f3b5914aedb1a78f5eb3a23b4e4fc6ba9214a54bb5a07c3",
+  ]
+}

--- a/deploy/aws/tofu/README.md
+++ b/deploy/aws/tofu/README.md
@@ -1,0 +1,42 @@
+# AWS EKS Phase 1 (OpenTofu)
+
+Scaffold for VPC, EKS managed node group, EBS CSI addon, and optional IRSA/S3.
+
+**Default variable values target a cheap non-prod lab** (1× Spot node, no NAT, no backup bucket).
+
+## Modules
+
+| Module | Resources |
+|--------|-----------|
+| `vpc` | VPC, subnets, IGW, optional single NAT |
+| `eks` | EKS cluster, Spot/On-Demand node group, OIDC, EBS CSI |
+| `irsa` | Optional SQL backup + External Secrets roles |
+
+## Cost levers
+
+| Variable | Cheap dev | Scale up |
+|----------|-----------|----------|
+| `enable_nat_gateway` | `false` | `true` (private nodes) |
+| `node_capacity_type` | `SPOT` | `ON_DEMAND` |
+| `node_desired_size` | `1` | `2+` |
+| `node_instance_types` | `["t3.xlarge"]` | `["m6i.large"]` etc. |
+| `create_backup_bucket` | `false` | `true` + prod k8s overlay |
+| `enable_external_secrets_irsa` | `false` | `true` + prod k8s overlay |
+
+Pair tofu with `deploy/aws/k8s/overlays/dev` for minimal manifests.
+
+## Local run
+
+```powershell
+cd deploy/aws/tofu
+copy environments\dev\terraform.tfvars.example terraform.tfvars
+tofu init
+tofu fmt -check -recursive
+tofu validate
+tofu plan
+```
+
+## CI
+
+- `.github/workflows/deploy-aws-phase1.yml`
+- `.github/workflows/deploy-aws-k8s.yml` (`profile=dev` for cheap overlay)

--- a/deploy/aws/tofu/environments/dev/backend.tf.example
+++ b/deploy/aws/tofu/environments/dev/backend.tf.example
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "myapp-tfstate-dev"
+    key            = "aws/eks/terraform.tfstate"
+    region         = "eu-west-1"
+    dynamodb_table = "myapp-tf-locks"
+    encrypt        = true
+  }
+}

--- a/deploy/aws/tofu/environments/dev/terraform.tfvars.example
+++ b/deploy/aws/tofu/environments/dev/terraform.tfvars.example
@@ -1,0 +1,24 @@
+# Cheap dev defaults — scale up for staging/prod via variables below.
+aws_region  = "eu-west-1"
+project     = "myapp"
+environment = "dev"
+
+vpc_cidr             = "10.70.0.0/16"
+public_subnet_cidrs  = ["10.70.1.0/24", "10.70.2.0/24"]
+private_subnet_cidrs = ["10.70.11.0/24", "10.70.12.0/24"]
+
+# ~$32/mo saved: nodes run in public subnets with public IPs.
+enable_nat_gateway = false
+
+kubernetes_version  = "1.30"
+node_instance_types = ["t3.xlarge"]
+node_capacity_type  = "SPOT"
+node_desired_size   = 1
+node_min_size       = 1
+node_max_size       = 2
+
+# Off for dev — enable with deploy/aws/k8s/overlays/prod.
+create_backup_bucket         = false
+enable_external_secrets_irsa = false
+
+# backup_bucket_name = "myapp-dev-sql-backups-unique-suffix"

--- a/deploy/aws/tofu/locals.tf
+++ b/deploy/aws/tofu/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+  base_tags = merge(
+    {
+      Project     = var.project
+      Environment = var.environment
+      ManagedBy   = "opentofu"
+    },
+    var.tags,
+  )
+}

--- a/deploy/aws/tofu/main.tf
+++ b/deploy/aws/tofu/main.tf
@@ -1,0 +1,58 @@
+locals {
+  cluster_subnet_ids = concat(module.vpc.private_subnet_ids, module.vpc.public_subnet_ids)
+  node_subnet_ids    = var.enable_nat_gateway ? module.vpc.private_subnet_ids : module.vpc.public_subnet_ids
+}
+
+module "vpc" {
+  source = "./modules/vpc"
+
+  name_prefix          = local.name_prefix
+  vpc_cidr             = var.vpc_cidr
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  enable_nat_gateway   = var.enable_nat_gateway
+  tags                 = local.base_tags
+}
+
+module "eks" {
+  source = "./modules/eks"
+
+  name_prefix         = local.name_prefix
+  kubernetes_version  = var.kubernetes_version
+  vpc_id              = module.vpc.vpc_id
+  cluster_subnet_ids  = local.cluster_subnet_ids
+  node_subnet_ids     = local.node_subnet_ids
+  node_instance_types = var.node_instance_types
+  node_capacity_type  = var.node_capacity_type
+  node_desired_size   = var.node_desired_size
+  node_min_size       = var.node_min_size
+  node_max_size       = var.node_max_size
+  tags                = local.base_tags
+}
+
+resource "aws_s3_bucket" "sql_backups" {
+  count  = var.create_backup_bucket ? 1 : 0
+  bucket = var.backup_bucket_name != "" ? var.backup_bucket_name : "${local.name_prefix}-sql-backups"
+}
+
+resource "aws_s3_bucket_versioning" "sql_backups" {
+  count  = var.create_backup_bucket ? 1 : 0
+  bucket = aws_s3_bucket.sql_backups[0].id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+module "irsa" {
+  source = "./modules/irsa"
+
+  name_prefix                  = local.name_prefix
+  oidc_provider_arn            = module.eks.oidc_provider_arn
+  oidc_provider_url            = module.eks.oidc_provider_url
+  backup_bucket_arn            = var.create_backup_bucket ? aws_s3_bucket.sql_backups[0].arn : ""
+  secrets_manager_prefix       = "myapp/${var.environment}/"
+  create_sql_backup_role       = var.create_backup_bucket
+  create_external_secrets_role = var.enable_external_secrets_irsa
+  tags                         = local.base_tags
+}

--- a/deploy/aws/tofu/modules/eks/main.tf
+++ b/deploy/aws/tofu/modules/eks/main.tf
@@ -1,0 +1,105 @@
+variable "name_prefix" { type = string }
+variable "kubernetes_version" { type = string }
+variable "vpc_id" { type = string }
+variable "node_subnet_ids" { type = list(string) }
+variable "cluster_subnet_ids" { type = list(string) }
+variable "node_instance_types" { type = list(string) }
+variable "node_capacity_type" { type = string }
+variable "node_desired_size" { type = number }
+variable "node_min_size" { type = number }
+variable "node_max_size" { type = number }
+variable "tags" { type = map(string) }
+
+resource "aws_iam_role" "cluster" {
+  name = "${var.name_prefix}-eks-cluster"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = { Service = "eks.amazonaws.com" }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = "${var.name_prefix}-eks"
+  role_arn = aws_iam_role.cluster.arn
+  version  = var.kubernetes_version
+
+  vpc_config {
+    subnet_ids              = var.cluster_subnet_ids
+    endpoint_private_access = true
+    endpoint_public_access  = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_iam_openid_connect_provider" "this" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
+  url             = aws_eks_cluster.this.identity[0].oidc[0].issuer
+  tags            = var.tags
+}
+
+resource "aws_iam_role" "node" {
+  name = "${var.name_prefix}-eks-node"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "node_worker" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_cni" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_ecr" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node.name
+}
+
+resource "aws_eks_node_group" "this" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "${var.name_prefix}-ng"
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = var.node_subnet_ids
+  instance_types  = var.node_instance_types
+  capacity_type   = var.node_capacity_type
+
+  scaling_config {
+    desired_size = var.node_desired_size
+    min_size     = var.node_min_size
+    max_size     = var.node_max_size
+  }
+
+  tags = var.tags
+}
+
+resource "aws_eks_addon" "ebs_csi" {
+  cluster_name = aws_eks_cluster.this.name
+  addon_name   = "aws-ebs-csi-driver"
+  tags         = var.tags
+}

--- a/deploy/aws/tofu/modules/eks/outputs.tf
+++ b/deploy/aws/tofu/modules/eks/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_name" {
+  value = aws_eks_cluster.this.name
+}
+
+output "cluster_endpoint" {
+  value = aws_eks_cluster.this.endpoint
+}
+
+output "cluster_arn" {
+  value = aws_eks_cluster.this.arn
+}
+
+output "oidc_provider_arn" {
+  value = aws_iam_openid_connect_provider.this.arn
+}
+
+output "oidc_provider_url" {
+  value = aws_eks_cluster.this.identity[0].oidc[0].issuer
+}

--- a/deploy/aws/tofu/modules/irsa/main.tf
+++ b/deploy/aws/tofu/modules/irsa/main.tf
@@ -1,0 +1,105 @@
+variable "name_prefix" { type = string }
+variable "oidc_provider_arn" { type = string }
+variable "oidc_provider_url" { type = string }
+variable "backup_bucket_arn" { type = string }
+variable "secrets_manager_prefix" { type = string }
+variable "create_sql_backup_role" { type = bool }
+variable "create_external_secrets_role" { type = bool }
+variable "tags" { type = map(string) }
+
+locals {
+  oidc_provider_host = replace(var.oidc_provider_url, "https://", "")
+}
+
+data "aws_iam_policy_document" "sql_backup_assume" {
+  count = var.create_sql_backup_role ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [var.oidc_provider_arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_host}:sub"
+      values   = ["system:serviceaccount:myapp-apps:sql-backup"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_host}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "sql_backup" {
+  count              = var.create_sql_backup_role ? 1 : 0
+  name               = "${var.name_prefix}-sql-backup"
+  assume_role_policy = data.aws_iam_policy_document.sql_backup_assume[0].json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "sql_backup" {
+  count = var.create_sql_backup_role ? 1 : 0
+
+  statement {
+    actions   = ["s3:PutObject", "s3:AbortMultipartUpload"]
+    resources = ["${var.backup_bucket_arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "sql_backup" {
+  count  = var.create_sql_backup_role ? 1 : 0
+  name   = "${var.name_prefix}-sql-backup"
+  role   = aws_iam_role.sql_backup[0].id
+  policy = data.aws_iam_policy_document.sql_backup[0].json
+}
+
+data "aws_iam_policy_document" "external_secrets_assume" {
+  count = var.create_external_secrets_role ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [var.oidc_provider_arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_host}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "${local.oidc_provider_host}:sub"
+      values = [
+        "system:serviceaccount:myapp-apps:external-secrets",
+        "system:serviceaccount:myapp-platform:external-secrets",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "external_secrets" {
+  count              = var.create_external_secrets_role ? 1 : 0
+  name               = "${var.name_prefix}-external-secrets"
+  assume_role_policy = data.aws_iam_policy_document.external_secrets_assume[0].json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "external_secrets" {
+  count = var.create_external_secrets_role ? 1 : 0
+
+  statement {
+    actions   = ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
+    resources = ["arn:aws:secretsmanager:*:*:secret:${var.secrets_manager_prefix}*"]
+  }
+}
+
+resource "aws_iam_role_policy" "external_secrets" {
+  count  = var.create_external_secrets_role ? 1 : 0
+  name   = "${var.name_prefix}-external-secrets"
+  role   = aws_iam_role.external_secrets[0].id
+  policy = data.aws_iam_policy_document.external_secrets[0].json
+}

--- a/deploy/aws/tofu/modules/irsa/outputs.tf
+++ b/deploy/aws/tofu/modules/irsa/outputs.tf
@@ -1,0 +1,7 @@
+output "sql_backup_role_arn" {
+  value = length(aws_iam_role.sql_backup) > 0 ? aws_iam_role.sql_backup[0].arn : null
+}
+
+output "external_secrets_role_arn" {
+  value = length(aws_iam_role.external_secrets) > 0 ? aws_iam_role.external_secrets[0].arn : null
+}

--- a/deploy/aws/tofu/modules/vpc/main.tf
+++ b/deploy/aws/tofu/modules/vpc/main.tf
@@ -1,0 +1,87 @@
+variable "name_prefix" { type = string }
+variable "vpc_cidr" { type = string }
+variable "public_subnet_cidrs" { type = list(string) }
+variable "private_subnet_cidrs" { type = list(string) }
+variable "enable_nat_gateway" { type = bool }
+variable "tags" { type = map(string) }
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags                 = merge(var.tags, { Name = "${var.name_prefix}-vpc" })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(var.tags, { Name = "${var.name_prefix}-igw" })
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+  tags                    = merge(var.tags, { Name = "${var.name_prefix}-public-${count.index + 1}" })
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  tags              = merge(var.tags, { Name = "${var.name_prefix}-private-${count.index + 1}" })
+}
+
+resource "aws_eip" "nat" {
+  count  = var.enable_nat_gateway ? 1 : 0
+  domain = "vpc"
+  tags   = merge(var.tags, { Name = "${var.name_prefix}-nat-eip" })
+}
+
+resource "aws_nat_gateway" "this" {
+  count         = var.enable_nat_gateway ? 1 : 0
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = aws_subnet.public[0].id
+  tags          = merge(var.tags, { Name = "${var.name_prefix}-nat" })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+  tags = merge(var.tags, { Name = "${var.name_prefix}-public-rt" })
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  dynamic "route" {
+    for_each = var.enable_nat_gateway ? [1] : []
+    content {
+      cidr_block     = "0.0.0.0/0"
+      nat_gateway_id = aws_nat_gateway.this[0].id
+    }
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-private-rt" })
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(aws_subnet.public)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(aws_subnet.private)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/deploy/aws/tofu/modules/vpc/outputs.tf
+++ b/deploy/aws/tofu/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}

--- a/deploy/aws/tofu/outputs.tf
+++ b/deploy/aws/tofu/outputs.tf
@@ -1,0 +1,36 @@
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "eks_cluster_name" {
+  value = module.eks.cluster_name
+}
+
+output "eks_cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "eks_cluster_arn" {
+  value = module.eks.cluster_arn
+}
+
+output "oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}
+
+output "node_subnet_ids" {
+  description = "Subnets used by the node group (public when NAT is disabled)."
+  value       = local.node_subnet_ids
+}
+
+output "sql_backup_role_arn" {
+  value = module.irsa.sql_backup_role_arn
+}
+
+output "external_secrets_role_arn" {
+  value = module.irsa.external_secrets_role_arn
+}
+
+output "backup_bucket_name" {
+  value = var.create_backup_bucket ? aws_s3_bucket.sql_backups[0].bucket : null
+}

--- a/deploy/aws/tofu/providers.tf
+++ b/deploy/aws/tofu/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.base_tags
+  }
+}

--- a/deploy/aws/tofu/variables.tf
+++ b/deploy/aws/tofu/variables.tf
@@ -1,0 +1,103 @@
+variable "aws_region" {
+  description = "AWS region for all resources."
+  type        = string
+}
+
+variable "project" {
+  description = "Project logical name."
+  type        = string
+  default     = "myapp"
+}
+
+variable "environment" {
+  description = "Environment slug."
+  type        = string
+  default     = "dev"
+}
+
+variable "tags" {
+  description = "Additional resource tags."
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR block."
+  type        = string
+  default     = "10.70.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  description = "Public subnet CIDRs (EKS requires at least two AZs)."
+  type        = list(string)
+  default     = ["10.70.1.0/24", "10.70.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "Private subnet CIDRs (used when NAT gateway is enabled)."
+  type        = list(string)
+  default     = ["10.70.11.0/24", "10.70.12.0/24"]
+}
+
+variable "enable_nat_gateway" {
+  description = "NAT gateway + EIP (~$32/mo). Disable for cheap dev; nodes use public subnets."
+  type        = bool
+  default     = false
+}
+
+variable "kubernetes_version" {
+  description = "EKS Kubernetes version."
+  type        = string
+  default     = "1.30"
+}
+
+variable "node_instance_types" {
+  description = "EKS managed node group instance types. t3.xlarge fits SQL + dev stack on one node."
+  type        = list(string)
+  default     = ["t3.xlarge"]
+}
+
+variable "node_capacity_type" {
+  description = "ON_DEMAND or SPOT (Spot is cheaper for non-prod)."
+  type        = string
+  default     = "SPOT"
+
+  validation {
+    condition     = contains(["ON_DEMAND", "SPOT"], var.node_capacity_type)
+    error_message = "node_capacity_type must be ON_DEMAND or SPOT."
+  }
+}
+
+variable "node_desired_size" {
+  type    = number
+  default = 1
+}
+
+variable "node_min_size" {
+  type    = number
+  default = 1
+}
+
+variable "node_max_size" {
+  description = "Upper bound for cluster-autoscaler / manual scale-out."
+  type        = number
+  default     = 2
+}
+
+variable "create_backup_bucket" {
+  description = "S3 bucket for SQL backups (prod overlay). Off by default for cheap dev."
+  type        = bool
+  default     = false
+}
+
+variable "backup_bucket_name" {
+  description = "Optional explicit S3 bucket name when create_backup_bucket is true."
+  type        = string
+  default     = ""
+}
+
+variable "enable_external_secrets_irsa" {
+  description = "IAM role for External Secrets Operator (prod overlay)."
+  type        = bool
+  default     = false
+}

--- a/deploy/aws/tofu/versions.tf
+++ b/deploy/aws/tofu/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.80.0"
+    }
+  }
+}

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,33 @@
+# Cloud-agnostic Kubernetes manifests (Tier 0)
+
+Portable workloads for the ERP microservices stack. No cloud provider assumptions.
+
+## Layout
+
+```text
+base/
+  platform/   namespaces, Redis
+  dapr/       Dapr config and Redis-backed components
+  sql/        SQL Server StatefulSet, bootstrap job (no backup)
+  apps/       microservices, gateway, Aspire dashboard
+overlays/
+  dev/        self-signed gateway TLS
+  prod/       Let's Encrypt ClusterIssuers + ingress host patch
+contracts/    service catalog and secret key schemas
+```
+
+## Quick validate
+
+```powershell
+kubectl kustomize deploy/k8s/overlays/dev
+kubectl kustomize deploy/k8s/overlays/prod
+```
+
+Secrets must exist in the cluster before apply (`redis-secrets`, `app-secrets`, `sql-secrets`, etc.). See `contracts/`.
+
+## Cloud-specific overlays
+
+| Cloud | Overlay path |
+|-------|----------------|
+| AWS EKS | `deploy/aws/k8s/overlays/` |
+| OCI OKE | `deploy/oci/k8s/` (legacy; not yet on shared base) |

--- a/deploy/k8s/base/apps/aspire-dashboard.yaml
+++ b/deploy/k8s/base/apps/aspire-dashboard.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aspire-dashboard
+  namespace: myapp-platform
+  labels:
+    app.kubernetes.io/name: aspire-dashboard
+    app.kubernetes.io/part-of: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: aspire-dashboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: aspire-dashboard
+        app.kubernetes.io/part-of: myapp
+    spec:
+      containers:
+        - name: aspire-dashboard
+          image: mcr.microsoft.com/dotnet/aspire-dashboard:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: ui
+              containerPort: 18888
+            - name: otlp-grpc
+              containerPort: 18889
+            - name: otlp-http
+              containerPort: 18890
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Production"
+            - name: ASPNETCORE_URLS
+              value: "http://+:18888"
+            - name: ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL
+              value: "http://0.0.0.0:18889"
+            - name: ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL
+              value: "http://0.0.0.0:18890"
+            - name: DASHBOARD__OTLP__AUTHMODE
+              value: "ApiKey"
+            - name: DASHBOARD__OTLP__PRIMARYAPIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: aspire-secrets
+                  key: otlp-key
+            - name: DASHBOARD__TELEMETRYLIMITS__MAXLOGCOUNT
+              value: "50000"
+            - name: DASHBOARD__TELEMETRYLIMITS__MAXTRACECOUNT
+              value: "50000"
+            - name: DASHBOARD__TELEMETRYLIMITS__MAXMETRICCOUNT
+              value: "50000"
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 18888
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 18888
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "256Mi"
+            limits:
+              cpu: "300m"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aspire-dashboard
+  namespace: myapp-platform
+  labels:
+    app.kubernetes.io/name: aspire-dashboard
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: aspire-dashboard
+  ports:
+    - name: ui
+      port: 18888
+      targetPort: 18888
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 18889
+    - name: otlp-http
+      port: 4318
+      targetPort: 18890
+

--- a/deploy/k8s/base/apps/auth-service.yaml
+++ b/deploy/k8s/base/apps/auth-service.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: auth-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: auth-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: auth-service
+        app.kubernetes.io/part-of: myapp
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "auth-service"
+        dapr.io/app-port: "8080"
+        dapr.io/log-level: "info"
+        dapr.io/config: "daprConfig"
+    spec:
+      containers:
+        - name: auth-service
+          image: ghcr.io/replace-org/replace-repo/myapp-auth-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 6
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Development"
+            - name: FRONTEND_ORIGIN
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: FRONTEND_ORIGIN
+            - name: Jwt__Issuer
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Issuer
+            - name: Jwt__Audience
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Audience
+            - name: Jwt__SecretKey
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: jwt-secret-key
+            - name: ConnectionStrings__cache
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: redis-connection
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://aspire-dashboard.myapp-platform.svc.cluster.local:4317"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "grpc"
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: otlp-header
+            - name: ConnectionStrings__AuthDb
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: sql-connection-authdb
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "600m"
+              memory: "768Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: auth-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: auth-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/deploy/k8s/base/apps/billing-service.yaml
+++ b/deploy/k8s/base/apps/billing-service.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: billing-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: billing-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: billing-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: billing-service
+        app.kubernetes.io/part-of: myapp
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "billing-service"
+        dapr.io/app-port: "8080"
+        dapr.io/log-level: "info"
+        dapr.io/config: "daprConfig"
+    spec:
+      containers:
+        - name: billing-service
+          image: ghcr.io/replace-org/replace-repo/myapp-billing-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 6
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Development"
+            - name: FRONTEND_ORIGIN
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: FRONTEND_ORIGIN
+            - name: Jwt__Issuer
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Issuer
+            - name: Jwt__Audience
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Audience
+            - name: Jwt__SecretKey
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: jwt-secret-key
+            - name: ConnectionStrings__cache
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: redis-connection
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://aspire-dashboard.myapp-platform.svc.cluster.local:4317"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "grpc"
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: otlp-header
+            - name: ConnectionStrings__BillingDb
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: sql-connection-billingdb
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "600m"
+              memory: "768Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: billing-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: billing-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: billing-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/deploy/k8s/base/apps/crm-service.yaml
+++ b/deploy/k8s/base/apps/crm-service.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crm-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: crm-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: crm-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: crm-service
+        app.kubernetes.io/part-of: myapp
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "crm-service"
+        dapr.io/app-port: "8080"
+        dapr.io/log-level: "info"
+        dapr.io/config: "daprConfig"
+    spec:
+      containers:
+        - name: crm-service
+          image: ghcr.io/replace-org/replace-repo/myapp-crm-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 6
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Development"
+            - name: FRONTEND_ORIGIN
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: FRONTEND_ORIGIN
+            - name: Jwt__Issuer
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Issuer
+            - name: Jwt__Audience
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Audience
+            - name: Jwt__SecretKey
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: jwt-secret-key
+            - name: ConnectionStrings__cache
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: redis-connection
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://aspire-dashboard.myapp-platform.svc.cluster.local:4317"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "grpc"
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: otlp-header
+            - name: ConnectionStrings__CrmDb
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: sql-connection-crmdb
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "600m"
+              memory: "768Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: crm-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: crm-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: crm-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/deploy/k8s/base/apps/gateway.yaml
+++ b/deploy/k8s/base/apps/gateway.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/part-of: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gateway
+        app.kubernetes.io/part-of: myapp
+    spec:
+      containers:
+        - name: gateway
+          image: ghcr.io/replace-org/replace-repo/myapp-gateway:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 6
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Development"
+            - name: FRONTEND_ORIGIN
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: FRONTEND_ORIGIN
+            - name: Jwt__SecretKey
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: jwt-secret-key
+            - name: Jwt__Issuer
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Issuer
+            - name: Jwt__Audience
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Audience
+            - name: Jwt__RequireHttpsMetadata
+              value: "false"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://aspire-dashboard.myapp-platform.svc.cluster.local:4317"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "grpc"
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: otlp-header
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "600m"
+              memory: "768Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: gateway
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gateway
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: gateway
+  annotations:
+    cert-manager.io/issuer: gateway-selfsigned
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - gateway.local
+      secretName: gateway-tls
+  rules:
+    - host: gateway.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: gateway
+                port:
+                  number: 8080

--- a/deploy/k8s/base/apps/inventory-service.yaml
+++ b/deploy/k8s/base/apps/inventory-service.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: inventory-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: inventory-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: inventory-service
+        app.kubernetes.io/part-of: myapp
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "inventory-service"
+        dapr.io/app-port: "8080"
+        dapr.io/log-level: "info"
+        dapr.io/config: "daprConfig"
+    spec:
+      containers:
+        - name: inventory-service
+          image: ghcr.io/replace-org/replace-repo/myapp-inventory-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 6
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Development"
+            - name: FRONTEND_ORIGIN
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: FRONTEND_ORIGIN
+            - name: Jwt__Issuer
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Issuer
+            - name: Jwt__Audience
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Audience
+            - name: Jwt__SecretKey
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: jwt-secret-key
+            - name: ConnectionStrings__cache
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: redis-connection
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://aspire-dashboard.myapp-platform.svc.cluster.local:4317"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "grpc"
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: otlp-header
+            - name: ConnectionStrings__InventoryDb
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: sql-connection-inventorydb
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "600m"
+              memory: "768Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: inventory-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: inventory-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/deploy/k8s/base/apps/kustomization.yaml
+++ b/deploy/k8s/base/apps/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: myapp-apps
+
+resources:
+  - auth-service.yaml
+  - billing-service.yaml
+  - crm-service.yaml
+  - inventory-service.yaml
+  - orders-service.yaml
+  - purchasing-service.yaml
+  - sales-service.yaml
+  - gateway.yaml
+  - aspire-dashboard.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/k8s/base/apps/orders-service.yaml
+++ b/deploy/k8s/base/apps/orders-service.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orders-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: orders-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: orders-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: orders-service
+        app.kubernetes.io/part-of: myapp
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "orders-service"
+        dapr.io/app-port: "8080"
+        dapr.io/log-level: "info"
+        dapr.io/config: "daprConfig"
+    spec:
+      containers:
+        - name: orders-service
+          image: ghcr.io/replace-org/replace-repo/myapp-orders-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 6
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Development"
+            - name: FRONTEND_ORIGIN
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: FRONTEND_ORIGIN
+            - name: Jwt__Issuer
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Issuer
+            - name: Jwt__Audience
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Audience
+            - name: Jwt__SecretKey
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: jwt-secret-key
+            - name: ConnectionStrings__cache
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: redis-connection
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://aspire-dashboard.myapp-platform.svc.cluster.local:4317"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "grpc"
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: otlp-header
+            - name: ConnectionStrings__OrdersDb
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: sql-connection-ordersdb
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "600m"
+              memory: "768Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: orders-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: orders-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: orders-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/deploy/k8s/base/apps/purchasing-service.yaml
+++ b/deploy/k8s/base/apps/purchasing-service.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: purchasing-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: purchasing-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: purchasing-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: purchasing-service
+        app.kubernetes.io/part-of: myapp
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "purchasing-service"
+        dapr.io/app-port: "8080"
+        dapr.io/log-level: "info"
+        dapr.io/config: "daprConfig"
+    spec:
+      containers:
+        - name: purchasing-service
+          image: ghcr.io/replace-org/replace-repo/myapp-purchasing-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 6
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Development"
+            - name: FRONTEND_ORIGIN
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: FRONTEND_ORIGIN
+            - name: Jwt__Issuer
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Issuer
+            - name: Jwt__Audience
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Audience
+            - name: Jwt__SecretKey
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: jwt-secret-key
+            - name: ConnectionStrings__cache
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: redis-connection
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://aspire-dashboard.myapp-platform.svc.cluster.local:4317"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "grpc"
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: otlp-header
+            - name: ConnectionStrings__PurchasingDb
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: sql-connection-purchasingdb
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "600m"
+              memory: "768Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: purchasing-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: purchasing-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: purchasing-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/deploy/k8s/base/apps/sales-service.yaml
+++ b/deploy/k8s/base/apps/sales-service.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sales-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: sales-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sales-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sales-service
+        app.kubernetes.io/part-of: myapp
+      annotations:
+        dapr.io/enabled: "true"
+        dapr.io/app-id: "sales-service"
+        dapr.io/app-port: "8080"
+        dapr.io/log-level: "info"
+        dapr.io/config: "daprConfig"
+    spec:
+      containers:
+        - name: sales-service
+          image: ghcr.io/replace-org/replace-repo/myapp-sales-service:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 6
+          env:
+            - name: ASPNETCORE_URLS
+              value: "http://+:8080"
+            - name: ASPNETCORE_ENVIRONMENT
+              value: "Development"
+            - name: FRONTEND_ORIGIN
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: FRONTEND_ORIGIN
+            - name: Jwt__Issuer
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Issuer
+            - name: Jwt__Audience
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: Jwt__Audience
+            - name: Jwt__SecretKey
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: jwt-secret-key
+            - name: ConnectionStrings__cache
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: redis-connection
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://aspire-dashboard.myapp-platform.svc.cluster.local:4317"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "grpc"
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: otlp-header
+            - name: ConnectionStrings__SalesDb
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: sql-connection-salesdb
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "600m"
+              memory: "768Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sales-service
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: sales-service
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: sales-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/deploy/k8s/base/dapr/components/dapr-config.yaml
+++ b/deploy/k8s/base/dapr/components/dapr-config.yaml
@@ -1,0 +1,44 @@
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: daprConfig
+  namespace: myapp-apps
+spec:
+  tracing:
+    samplingRate: "1"
+    otel:
+      endpointAddress: "aspire-dashboard.myapp-platform.svc.cluster.local:4317"
+      isSecure: false
+      protocol: grpc
+      timeout: "30s"
+      headers:
+        - name: x-otlp-api-key
+          secretKeyRef:
+            name: app-secrets
+            key: otlp-api-key
+  mtls:
+    enabled: false
+  accessControl:
+    defaultAction: allow
+    trustDomain: localhost
+    policies:
+      - appId: gateway
+        actions: ["*"]
+      - appId: auth-service
+        actions: ["invoke/*"]
+      - appId: billing-service
+        actions: ["invoke/*"]
+      - appId: inventory-service
+        actions: ["invoke/*"]
+      - appId: orders-service
+        actions: ["invoke/*"]
+      - appId: purchasing-service
+        actions: ["invoke/*"]
+      - appId: sales-service
+        actions: ["invoke/*"]
+      - appId: crm-service
+        actions: ["invoke/*"]
+  secrets:
+    scopes:
+      - storeName: local-secrets
+        defaultAccess: allow

--- a/deploy/k8s/base/dapr/components/pubsub.yaml
+++ b/deploy/k8s/base/dapr/components/pubsub.yaml
@@ -1,0 +1,25 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub
+  namespace: myapp-apps
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+    - name: redisHost
+      value: redis-master.myapp-platform.svc.cluster.local:6379
+    - name: redisPassword
+      secretKeyRef:
+        name: redis-secrets
+        key: redis-password
+    - name: enableTLS
+      value: "false"
+scopes:
+  - auth-service
+  - billing-service
+  - inventory-service
+  - orders-service
+  - purchasing-service
+  - sales-service
+  - crm-service

--- a/deploy/k8s/base/dapr/components/statestore.yaml
+++ b/deploy/k8s/base/dapr/components/statestore.yaml
@@ -1,0 +1,27 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+  namespace: myapp-apps
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+    - name: redisHost
+      value: redis-master.myapp-platform.svc.cluster.local:6379
+    - name: redisPassword
+      secretKeyRef:
+        name: redis-secrets
+        key: redis-password
+    - name: actorStateStore
+      value: "true"
+    - name: enableTLS
+      value: "false"
+scopes:
+  - auth-service
+  - billing-service
+  - inventory-service
+  - orders-service
+  - purchasing-service
+  - sales-service
+  - crm-service

--- a/deploy/k8s/base/platform/kustomization.yaml
+++ b/deploy/k8s/base/platform/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespaces.yaml
+  - redis.yaml
+
+configMapGenerator:
+  - name: platform-bootstrap
+    namespace: myapp-platform
+    literals:
+      - PLATFORM_PHASE=phase2
+      - DAPR_STATESTORE_NAME=statestore
+      - DAPR_PUBSUB_NAME=pubsub
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/k8s/base/platform/namespaces.yaml
+++ b/deploy/k8s/base/platform/namespaces.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: myapp-platform
+  labels:
+    app.kubernetes.io/part-of: myapp
+    app.kubernetes.io/managed-by: gitops
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: myapp-apps
+  labels:
+    app.kubernetes.io/part-of: myapp
+    app.kubernetes.io/managed-by: gitops

--- a/deploy/k8s/base/platform/redis.yaml
+++ b/deploy/k8s/base/platform/redis.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+  namespace: myapp-platform
+  labels:
+    app.kubernetes.io/name: redis-master
+    app.kubernetes.io/part-of: myapp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis-master
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis-master
+        app.kubernetes.io/part-of: myapp
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secrets
+                  key: redis-password
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+              exec redis-server \
+                --save "" \
+                --appendonly no \
+                --requirepass "$REDIS_PASSWORD"
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "redis-cli -a \"$REDIS_PASSWORD\" ping | grep -q PONG"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "redis-cli -a \"$REDIS_PASSWORD\" ping | grep -q PONG"]
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  namespace: myapp-platform
+  labels:
+    app.kubernetes.io/name: redis-master
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redis-master
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379

--- a/deploy/k8s/base/sql/job-bootstrap-databases.yaml
+++ b/deploy/k8s/base/sql/job-bootstrap-databases.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sql-bootstrap-databases
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: sql-bootstrap-databases
+    app.kubernetes.io/part-of: myapp
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sql-bootstrap-databases
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: mcr.microsoft.com/mssql-tools:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sql-secrets
+                  key: sa-password
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              SQLCMD_BIN="/opt/mssql-tools18/bin/sqlcmd"
+              if [ ! -x "$SQLCMD_BIN" ]; then
+                SQLCMD_BIN="/opt/mssql-tools/bin/sqlcmd"
+              fi
+              echo "Waiting for SQL Server to be ready..."
+              until "$SQLCMD_BIN" -S sqlserver,1433 -U sa -P "$SA_PASSWORD" -Q "SELECT 1" >/dev/null 2>&1; do
+                sleep 5
+              done
+
+              echo "Creating service databases if they do not exist..."
+              "$SQLCMD_BIN" -S sqlserver,1433 -U sa -P "$SA_PASSWORD" -Q "
+              IF DB_ID('AuthDb') IS NULL CREATE DATABASE [AuthDb];
+              IF DB_ID('BillingDb') IS NULL CREATE DATABASE [BillingDb];
+              IF DB_ID('InventoryDb') IS NULL CREATE DATABASE [InventoryDb];
+              IF DB_ID('OrdersDb') IS NULL CREATE DATABASE [OrdersDb];
+              IF DB_ID('PurchasingDb') IS NULL CREATE DATABASE [PurchasingDb];
+              IF DB_ID('SalesDb') IS NULL CREATE DATABASE [SalesDb];
+              IF DB_ID('CrmDb') IS NULL CREATE DATABASE [CrmDb];
+              "
+
+              echo "Creating sqladmin login for connection-string parity..."
+              "$SQLCMD_BIN" -S sqlserver,1433 -U sa -P "$SA_PASSWORD" -Q "
+              IF NOT EXISTS (SELECT name FROM sys.server_principals WHERE name = 'sqladmin')
+              BEGIN
+                CREATE LOGIN [sqladmin] WITH PASSWORD = '$SA_PASSWORD', CHECK_POLICY = ON;
+              END
+              "
+
+              for db in AuthDb BillingDb InventoryDb OrdersDb PurchasingDb SalesDb CrmDb; do
+                "$SQLCMD_BIN" -S sqlserver,1433 -U sa -P "$SA_PASSWORD" -Q "
+                USE [$db];
+                IF NOT EXISTS (SELECT name FROM sys.database_principals WHERE name = 'sqladmin')
+                  CREATE USER [sqladmin] FOR LOGIN [sqladmin];
+                ALTER ROLE [db_owner] ADD MEMBER [sqladmin];
+                "
+              done
+
+              echo "Bootstrap complete."

--- a/deploy/k8s/base/sql/kustomization.yaml
+++ b/deploy/k8s/base/sql/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: myapp-apps
+
+resources:
+  - sql-pvc.yaml
+  - sql-service.yaml
+  - statefulset-mssql.yaml
+  - job-bootstrap-databases.yaml

--- a/deploy/k8s/base/sql/sql-pvc.yaml
+++ b/deploy/k8s/base/sql/sql-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mssql-data
+  namespace: myapp-apps
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi

--- a/deploy/k8s/base/sql/sql-service.yaml
+++ b/deploy/k8s/base/sql/sql-service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sqlserver
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: sqlserver
+    app.kubernetes.io/part-of: myapp
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: sqlserver
+  ports:
+    - name: tds
+      port: 1433
+      targetPort: 1433
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sqlserver-headless
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: sqlserver
+    app.kubernetes.io/part-of: myapp
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: sqlserver
+  ports:
+    - name: tds
+      port: 1433
+      targetPort: 1433

--- a/deploy/k8s/base/sql/statefulset-mssql.yaml
+++ b/deploy/k8s/base/sql/statefulset-mssql.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sqlserver
+  namespace: myapp-apps
+  labels:
+    app.kubernetes.io/name: sqlserver
+    app.kubernetes.io/part-of: myapp
+spec:
+  serviceName: sqlserver-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sqlserver
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sqlserver
+        app.kubernetes.io/part-of: myapp
+    spec:
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: mssql
+          image: mcr.microsoft.com/mssql/server:2022-latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 1433
+              name: tds
+          env:
+            - name: ACCEPT_EULA
+              value: "Y"
+            - name: MSSQL_SA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sql-secrets
+                  key: sa-password
+            - name: MSSQL_PID
+              value: "Developer"
+          resources:
+            requests:
+              cpu: "1"
+              memory: "4Gi"
+            limits:
+              cpu: "2"
+              memory: "8Gi"
+          readinessProbe:
+            tcpSocket:
+              port: 1433
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 12
+          livenessProbe:
+            tcpSocket:
+              port: 1433
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            failureThreshold: 6
+          volumeMounts:
+            - name: mssql-data
+              mountPath: /var/opt/mssql
+      volumes:
+        - name: mssql-data
+          persistentVolumeClaim:
+            claimName: mssql-data
+  updateStrategy:
+    type: RollingUpdate

--- a/deploy/k8s/contracts/README.md
+++ b/deploy/k8s/contracts/README.md
@@ -1,0 +1,38 @@
+# Secret key contracts
+
+These files document required Kubernetes secret shapes. They are **not** applied directly.
+
+| File | Secret name | Namespace |
+|------|-------------|-----------|
+| `secret-keys.app-secrets.yaml` | `app-secrets` | `myapp-apps` |
+| `secret-keys.sql-secrets.yaml` | `sql-secrets` | `myapp-apps` |
+
+Cloud overlays document additional backup-related keys (S3 on AWS, Object Storage on OCI).
+
+## Service catalog
+
+`services.yaml` is the single source of truth for:
+
+- GitHub Actions image build matrix (`.github/workflows/_reusable/build-service-images.yml`)
+- Image tag patching (`patch-k8s-image-tags.yml`)
+
+## Helm prerequisites (any cluster)
+
+Install before applying overlays:
+
+1. ingress-nginx
+2. cert-manager
+3. Dapr
+4. External Secrets Operator (optional; required for production secret sync)
+
+## Apply order
+
+```text
+1. Secrets (manual or ESO)
+2. kubectl apply -k deploy/k8s/base/platform
+3. kubectl apply -f deploy/k8s/base/dapr/components/*.yaml
+4. kubectl apply -k deploy/k8s/base/sql
+5. kubectl apply -k deploy/k8s/overlays/dev   # or prod
+```
+
+For AWS, use `deploy/aws/k8s/overlays/*` instead of step 5.

--- a/deploy/k8s/contracts/secret-keys.app-secrets.yaml
+++ b/deploy/k8s/contracts/secret-keys.app-secrets.yaml
@@ -1,0 +1,19 @@
+# Contract: keys required in myapp-apps/app-secrets (manual or ESO-managed).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets-contract
+  namespace: myapp-apps
+type: Opaque
+stringData:
+  jwt-secret-key: "<required>"
+  otlp-api-key: "<required>"
+  otlp-header: "<required>"
+  redis-connection: "<required>"
+  sql-connection-authdb: "<required>"
+  sql-connection-billingdb: "<required>"
+  sql-connection-inventorydb: "<required>"
+  sql-connection-ordersdb: "<required>"
+  sql-connection-purchasingdb: "<required>"
+  sql-connection-salesdb: "<required>"
+  sql-connection-crmdb: "<required>"

--- a/deploy/k8s/contracts/secret-keys.sql-secrets.yaml
+++ b/deploy/k8s/contracts/secret-keys.sql-secrets.yaml
@@ -1,0 +1,9 @@
+# Contract: portable SQL secret keys. Cloud-specific backup keys live in cloud overlay READMEs.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sql-secrets-contract
+  namespace: myapp-apps
+type: Opaque
+stringData:
+  sa-password: "<required>"

--- a/deploy/k8s/contracts/services.yaml
+++ b/deploy/k8s/contracts/services.yaml
@@ -1,0 +1,26 @@
+# Canonical service catalog for image builds and manifest tag patching.
+services:
+  - name: auth-service
+    dockerfile: src/MyApp.Auth/MyApp.Auth.API/Dockerfile
+  - name: billing-service
+    dockerfile: src/MyApp.Billing/MyApp.Billing.API/Dockerfile
+  - name: inventory-service
+    dockerfile: src/MyApp.Inventory/MyApp.Inventory.API/Dockerfile
+  - name: orders-service
+    dockerfile: src/MyApp.Orders/MyApp.Orders.API/Dockerfile
+  - name: purchasing-service
+    dockerfile: src/MyApp.Purchasing/MyApp.Purchasing.API/Dockerfile
+  - name: sales-service
+    dockerfile: src/MyApp.Sales/MyApp.Sales.API/Dockerfile
+  - name: crm-service
+    dockerfile: src/MyApp.Crm/MyApp.Crm.API/Dockerfile
+  - name: agentic-service
+    dockerfile: src/MyApp.Agentic/MyApp.Agentic.API/Dockerfile
+  - name: gateway
+    dockerfile: src/ErpApiGateway/Dockerfile
+
+image:
+  registry: ghcr.io
+  placeholder_org: replace-org
+  placeholder_repo: replace-repo
+  name_prefix: myapp

--- a/deploy/k8s/overlays/dev/gateway-tls-issuer.yaml
+++ b/deploy/k8s/overlays/dev/gateway-tls-issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: gateway-selfsigned
+  namespace: myapp-apps
+spec:
+  selfSigned: {}

--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/platform
+  - ../../base/sql
+  - ../../base/apps
+  - gateway-tls-issuer.yaml

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../dev
+  - letsencrypt-clusterissuers.yaml
+
+patchesStrategicMerge:
+  - patch-gateway-ingress-letsencrypt.yaml

--- a/deploy/k8s/overlays/prod/letsencrypt-clusterissuers.yaml
+++ b/deploy/k8s/overlays/prod/letsencrypt-clusterissuers.yaml
@@ -1,0 +1,29 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: replace-with-ops-email@example.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    email: replace-with-ops-email@example.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/deploy/k8s/overlays/prod/patch-gateway-ingress-letsencrypt.yaml
+++ b/deploy/k8s/overlays/prod/patch-gateway-ingress-letsencrypt.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gateway
+  namespace: myapp-apps
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    cert-manager.io/issuer: null
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  tls:
+    - hosts:
+        - api.replace-with-real-domain.com
+      secretName: gateway-tls
+  rules:
+    - host: api.replace-with-real-domain.com


### PR DESCRIPTION
Add end-to-end AWS deployment scaffolding: Kubernetes base manifests and AWS-specific overlays (dev/prod) including ExternalSecrets, backup CronJob, gp3 PVC patch and IRSA service accounts. Add OpenTofu (Terraform-compatible) environment under deploy/aws/tofu with modules for EKS, IRSA and VPC. Introduce GitHub Actions: reusable workflows for building service images, k8s validate/apply and image tag patching, plus deploy-aws-k8s.yml and a phase1 OpenTofu skeleton. Update devcontainer to use dotnet:10.0-noble and enable docker-in-docker feature.